### PR TITLE
feat(models): define email block domain model

### DIFF
--- a/EmailEditor.Tests/EmailEditor.Tests.csproj
+++ b/EmailEditor.Tests/EmailEditor.Tests.csproj
@@ -18,4 +18,8 @@
     <Using Include="Xunit" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\EmailEditor\EmailEditor.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/EmailEditor.Tests/Models/EmailDocumentTests.cs
+++ b/EmailEditor.Tests/Models/EmailDocumentTests.cs
@@ -1,0 +1,108 @@
+using EmailEditor.Models;
+
+namespace EmailEditor.Tests.Models;
+
+public class EmailDocumentTests
+{
+    [Fact]
+    public void EmailDocument_CanBeConstructedWithAllBlockTypes()
+    {
+        var blocks = new List<IEmailBlock>
+        {
+            new HeroBlock("https://example.com/img.jpg", "Hello World"),
+            new TextBlock("<p>Some text</p>"),
+            new ButtonBlock("Click Me", "https://example.com"),
+            new ImageBlock("https://example.com/img.jpg", "Alt text"),
+            new DividerBlock(),
+            new TwoColumnBlock("<p>Left</p>", "<p>Right</p>"),
+        };
+
+        var doc = new EmailDocument(
+            Subject: "Test Subject",
+            PreviewText: "Preview snippet",
+            FromName: "Sender Name",
+            FromAddress: "sender@example.com",
+            Blocks: blocks.AsReadOnly()
+        );
+
+        Assert.Equal("Test Subject", doc.Subject);
+        Assert.Equal("Preview snippet", doc.PreviewText);
+        Assert.Equal("Sender Name", doc.FromName);
+        Assert.Equal("sender@example.com", doc.FromAddress);
+        Assert.Equal(6, doc.Blocks.Count);
+    }
+
+    [Fact]
+    public void EmailDocument_Blocks_IsIReadOnlyList()
+    {
+        var doc = new EmailDocument("S", "P", "F", "f@f.com", new List<IEmailBlock>().AsReadOnly());
+        Assert.IsAssignableFrom<IReadOnlyList<IEmailBlock>>(doc.Blocks);
+    }
+
+    [Fact]
+    public void HeroBlock_HasCorrectProperties()
+    {
+        var block = new HeroBlock("https://img.url", "My Headline");
+        Assert.Equal("https://img.url", block.ImageUrl);
+        Assert.Equal("My Headline", block.Headline);
+    }
+
+    [Fact]
+    public void TextBlock_HasCorrectProperties()
+    {
+        var block = new TextBlock("<p>Hello</p>");
+        Assert.Equal("<p>Hello</p>", block.HtmlContent);
+    }
+
+    [Fact]
+    public void ButtonBlock_HasCorrectProperties_AndDefaults()
+    {
+        var block = new ButtonBlock("Click", "https://url.com");
+        Assert.Equal("Click", block.Label);
+        Assert.Equal("https://url.com", block.Url);
+        Assert.Equal("#000000", block.BackgroundColor);
+        Assert.Equal("#ffffff", block.TextColor);
+    }
+
+    [Fact]
+    public void ButtonBlock_AllowsCustomColors()
+    {
+        var block = new ButtonBlock("Click", "https://url.com", "#ff0000", "#00ff00");
+        Assert.Equal("#ff0000", block.BackgroundColor);
+        Assert.Equal("#00ff00", block.TextColor);
+    }
+
+    [Fact]
+    public void ImageBlock_HasCorrectProperties()
+    {
+        var block = new ImageBlock("https://img.url", "A photo");
+        Assert.Equal("https://img.url", block.ImageUrl);
+        Assert.Equal("A photo", block.AltText);
+    }
+
+    [Fact]
+    public void DividerBlock_ImplementsIEmailBlock()
+    {
+        IEmailBlock block = new DividerBlock();
+        Assert.NotNull(block);
+    }
+
+    [Fact]
+    public void TwoColumnBlock_HasCorrectProperties()
+    {
+        var block = new TwoColumnBlock("<p>Left</p>", "<p>Right</p>");
+        Assert.Equal("<p>Left</p>", block.LeftHtmlContent);
+        Assert.Equal("<p>Right</p>", block.RightHtmlContent);
+    }
+
+    [Fact]
+    public void AllBlockTypes_ImplementIEmailBlock()
+    {
+        Assert.IsAssignableFrom<IEmailBlock>(new HeroBlock("u", "h"));
+        Assert.IsAssignableFrom<IEmailBlock>(new TextBlock("t"));
+        Assert.IsAssignableFrom<IEmailBlock>(new ButtonBlock("l", "u"));
+        Assert.IsAssignableFrom<IEmailBlock>(new ImageBlock("u", "a"));
+        Assert.IsAssignableFrom<IEmailBlock>(new DividerBlock());
+        Assert.IsAssignableFrom<IEmailBlock>(new TwoColumnBlock("l", "r"));
+    }
+}

--- a/EmailEditor/Models/ButtonBlock.cs
+++ b/EmailEditor/Models/ButtonBlock.cs
@@ -1,0 +1,8 @@
+namespace EmailEditor.Models;
+
+public record ButtonBlock(
+    string Label,
+    string Url,
+    string BackgroundColor = "#000000",
+    string TextColor = "#ffffff"
+) : IEmailBlock;

--- a/EmailEditor/Models/DividerBlock.cs
+++ b/EmailEditor/Models/DividerBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public record DividerBlock() : IEmailBlock;

--- a/EmailEditor/Models/EmailDocument.cs
+++ b/EmailEditor/Models/EmailDocument.cs
@@ -1,0 +1,9 @@
+namespace EmailEditor.Models;
+
+public record EmailDocument(
+    string Subject,
+    string PreviewText,
+    string FromName,
+    string FromAddress,
+    IReadOnlyList<IEmailBlock> Blocks
+);

--- a/EmailEditor/Models/HeroBlock.cs
+++ b/EmailEditor/Models/HeroBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public record HeroBlock(string ImageUrl, string Headline) : IEmailBlock;

--- a/EmailEditor/Models/IEmailBlock.cs
+++ b/EmailEditor/Models/IEmailBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public interface IEmailBlock { }

--- a/EmailEditor/Models/ImageBlock.cs
+++ b/EmailEditor/Models/ImageBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public record ImageBlock(string ImageUrl, string AltText) : IEmailBlock;

--- a/EmailEditor/Models/TextBlock.cs
+++ b/EmailEditor/Models/TextBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public record TextBlock(string HtmlContent) : IEmailBlock;

--- a/EmailEditor/Models/TwoColumnBlock.cs
+++ b/EmailEditor/Models/TwoColumnBlock.cs
@@ -1,0 +1,3 @@
+namespace EmailEditor.Models;
+
+public record TwoColumnBlock(string LeftHtmlContent, string RightHtmlContent) : IEmailBlock;


### PR DESCRIPTION
## Summary
- Defines `IEmailBlock` marker interface and 6 block record types: `HeroBlock`, `TextBlock`, `ButtonBlock`, `ImageBlock`, `DividerBlock`, `TwoColumnBlock`
- Defines `EmailDocument` envelope record with Subject, PreviewText, FromName, FromAddress, and Blocks
- Adds project reference from `EmailEditor.Tests` to `EmailEditor`

## Test plan
- [x] 11 xUnit tests covering all block types, property values, default values, and `IReadOnlyList<IEmailBlock>` contract
- [x] All tests passing

Closes #2
Part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)