### PR TITLE
docs: add Obsidian documentation vault

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,97 @@
+---
+title: API Reference
+tags: [api, backend, csharp]
+---
+
+# API Reference
+
+> [!note] Not Yet Implemented
+> Tracked in [#4](https://github.com/shrinerp/email-editor/issues/4). This document describes the intended design.
+
+## Base URL
+
+```
+http://localhost:5261
+```
+
+## Endpoints
+
+### POST /api/generate
+
+Accepts an `EmailDocument` as JSON and returns the generated cross-email-client HTML.
+
+**Request**
+
+```http
+POST /api/generate
+Content-Type: application/json
+```
+
+```json
+{
+  "subject": "Welcome to our newsletter",
+  "previewText": "Here's what's new this week...",
+  "fromName": "Acme Corp",
+  "fromAddress": "hello@acme.com",
+  "blocks": [
+    {
+      "$type": "hero",
+      "imageUrl": "https://example.com/banner.jpg",
+      "headline": "Big News This Week"
+    },
+    {
+      "$type": "text",
+      "htmlContent": "<p>Hello <strong>world</strong></p>"
+    },
+    {
+      "$type": "button",
+      "label": "Read More",
+      "url": "https://example.com",
+      "backgroundColor": "#1a1a1a",
+      "textColor": "#ffffff"
+    },
+    {
+      "$type": "divider"
+    }
+  ]
+}
+```
+
+**Block `$type` values**
+
+| Value | Block type |
+|-------|-----------|
+| `hero` | [[domain-model#HeroBlock\|HeroBlock]] |
+| `text` | [[domain-model#TextBlock\|TextBlock]] |
+| `button` | [[domain-model#ButtonBlock\|ButtonBlock]] |
+| `image` | [[domain-model#ImageBlock\|ImageBlock]] |
+| `divider` | [[domain-model#DividerBlock\|DividerBlock]] |
+| `twoColumn` | [[domain-model#TwoColumnBlock\|TwoColumnBlock]] |
+
+**Response — 200 OK**
+
+```http
+Content-Type: text/html
+```
+
+Returns a complete HTML document string ready for download or iframe rendering.
+
+**Response — 400 Bad Request**
+
+Returned for malformed JSON or invalid block structure.
+
+```json
+{
+  "error": "Invalid block type: 'unknown'"
+}
+```
+
+## Security Notes
+
+> [!warning] Input Sanitization
+> All `htmlContent` fields (TextBlock, TwoColumnBlock) are sanitized server-side before being passed to the generator. This prevents XSS in the preview iframe.
+
+## Related
+
+- [[html-generator]] — what runs when this endpoint is called
+- [[frontend]] — how the SPA calls this endpoint

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,83 @@
+---
+title: Architecture
+tags: [architecture, backend, frontend]
+---
+
+# Architecture
+
+## Overview
+
+The Email Editor is a single-host, locally-running web application. ASP.NET Core serves both the REST API and the React SPA static files from a single process on `localhost`.
+
+```mermaid
+graph TD
+    Browser["Browser\n(React SPA)"]
+    API["ASP.NET Core\nWeb API"]
+    Generator["HtmlGeneratorService\n(C#)"]
+    Models["EmailDocument\n+ Block Models"]
+
+    Browser -- "POST /api/generate\n(EmailDocument JSON)" --> API
+    API --> Generator
+    Generator --> Models
+    Generator -- "HTML string" --> API
+    API -- "text/html response" --> Browser
+    Browser -- "iframe / download" --> Browser
+```
+
+## Layers
+
+### 1. Domain Models (`EmailEditor/Models/`)
+Pure C# records. No behavior, no rendering — just the data contracts the entire system is built on.
+
+See [[domain-model]].
+
+### 2. HTML Generator (`EmailEditor/Services/`)
+The core of the application. Takes an `EmailDocument` and returns a cross-email-client HTML string. All layout uses table-based structure with inlined CSS.
+
+See [[html-generator]].
+
+### 3. Web API (`EmailEditor/`)
+Minimal ASP.NET Core API. Exposes `POST /api/generate`. In production, also serves the React SPA from `wwwroot/`.
+
+See [[api]].
+
+### 4. React SPA (`EmailEditor/ClientApp/`)
+A Vite + React (TypeScript) app. Handles all user interaction: block palette, drag-drop canvas, block editors, preview, and download.
+
+See [[frontend]].
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant SPA as React SPA
+    participant API as ASP.NET Core API
+    participant Gen as HtmlGeneratorService
+
+    User->>SPA: Adds/edits blocks
+    User->>SPA: Clicks "Preview"
+    SPA->>API: POST /api/generate (EmailDocument JSON)
+    API->>Gen: Generate(emailDocument)
+    Gen-->>API: HTML string
+    API-->>SPA: text/html response
+    SPA->>User: Renders HTML in iframe
+    User->>SPA: Clicks "Download"
+    SPA->>User: .html file download
+```
+
+## Key Constraints
+
+> [!important] Cross-Email-Client HTML Rules
+> - **No flexbox** — not supported in Outlook
+> - **No CSS grid** — not supported in Outlook
+> - **Table-based layout only** — every structural element uses `<table>`
+> - **All CSS inlined** — no `<style>` blocks, no class-based styling
+> - **VML for Outlook buttons** — use `<!--[if mso]>` conditional comments for button backgrounds
+
+## Dev vs Production
+
+| Mode | SPA serving | API proxy |
+|------|------------|-----------|
+| Development | Vite dev server (`localhost:5173`) | Vite proxies `/api/*` → `localhost:5261` |
+| Production | ASP.NET Core serves `wwwroot/` | Same origin, no proxy needed |

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,84 @@
+---
+title: Dev Setup
+tags: [setup, development]
+---
+
+# Dev Setup
+
+## Prerequisites
+
+- [.NET 10 SDK](https://dotnet.microsoft.com/download)
+- [Node.js 20+](https://nodejs.org/) + npm
+- Git
+
+## Clone & Install
+
+```bash
+git clone https://github.com/shrinerp/email-editor.git
+cd email-editor
+
+# Install frontend dependencies
+cd EmailEditor/ClientApp
+npm install
+cd ../..
+```
+
+## Running Locally
+
+You need two terminals — one for the .NET API, one for the Vite dev server.
+
+**Terminal 1 — .NET API**
+```bash
+cd EmailEditor
+dotnet run
+# API available at http://localhost:5261
+```
+
+**Terminal 2 — React SPA**
+```bash
+cd EmailEditor/ClientApp
+npm run dev
+# SPA available at http://localhost:5173
+# /api/* proxied to http://localhost:5261
+```
+
+Open `http://localhost:5173` in your browser.
+
+> [!tip] Vite Proxy
+> In development, all `/api/*` requests from the React app are automatically forwarded to the .NET backend. You don't need to configure CORS.
+
+## Running Tests
+
+```bash
+# From repo root
+dotnet test
+```
+
+## Project Structure
+
+```
+email-editor/
+├── EmailEditor/               ← ASP.NET Core Web API
+│   ├── Models/                ← Domain model (IEmailBlock, block types)
+│   ├── Services/              ← HtmlGeneratorService (⚪ pending #3)
+│   ├── ClientApp/             ← React + Vite SPA
+│   ├── Program.cs             ← App host + API endpoints
+│   └── EmailEditor.csproj
+├── EmailEditor.Tests/         ← xUnit tests
+│   ├── Models/                ← Domain model tests
+│   └── Services/              ← Generator tests (⚪ pending #3)
+├── EmailEditor.slnx           ← Solution file
+└── docs/                      ← This documentation
+```
+
+## Branches & Workflow
+
+- All work is tracked via GitHub issues
+- Branch naming: `{issue-number}-{slug}` (e.g. `2-email-block-domain-model`)
+- Every change goes through a PR targeting `main`
+- TDD: write tests first
+
+## Related
+
+- [[architecture]] — how the pieces fit together
+- [[api]] — API endpoints and request/response shapes

--- a/docs/domain-model.md
+++ b/docs/domain-model.md
@@ -1,0 +1,148 @@
+---
+title: Domain Model
+tags: [backend, models, csharp]
+---
+
+# Domain Model
+
+All types live in `EmailEditor/Models/`. They are immutable C# records with no rendering logic.
+
+## EmailDocument
+
+The top-level envelope passed to the HTML generator and the API.
+
+```csharp
+public record EmailDocument(
+    string Subject,
+    string PreviewText,
+    string FromName,
+    string FromAddress,
+    IReadOnlyList<IEmailBlock> Blocks
+);
+```
+
+| Property | Purpose |
+|----------|---------|
+| `Subject` | Email subject line |
+| `PreviewText` | Inbox snippet (rendered as invisible text in HTML head) |
+| `FromName` | Sender display name |
+| `FromAddress` | Sender email address |
+| `Blocks` | Ordered list of content blocks |
+
+## IEmailBlock
+
+Marker interface implemented by all block types.
+
+```csharp
+public interface IEmailBlock { }
+```
+
+## Block Types
+
+### HeroBlock
+
+Full-width banner image with a headline.
+
+```csharp
+public record HeroBlock(string ImageUrl, string Headline) : IEmailBlock;
+```
+
+### TextBlock
+
+Rich text paragraph. `HtmlContent` is Quill output — post-processed server-side to inline all styles before rendering.
+
+```csharp
+public record TextBlock(string HtmlContent) : IEmailBlock;
+```
+
+> [!warning] HTML Content
+> `HtmlContent` must be sanitized server-side before rendering to prevent XSS in the preview iframe.
+
+### ButtonBlock
+
+Call-to-action button. Uses table-cell rendering with VML fallback for Outlook.
+
+```csharp
+public record ButtonBlock(
+    string Label,
+    string Url,
+    string BackgroundColor = "#000000",
+    string TextColor = "#ffffff"
+) : IEmailBlock;
+```
+
+### ImageBlock
+
+Standalone image with alt text.
+
+```csharp
+public record ImageBlock(string ImageUrl, string AltText) : IEmailBlock;
+```
+
+### DividerBlock
+
+Horizontal rule / spacer. No configurable properties.
+
+```csharp
+public record DividerBlock() : IEmailBlock;
+```
+
+### TwoColumnBlock
+
+Two side-by-side Quill content areas, each 50% width.
+
+```csharp
+public record TwoColumnBlock(string LeftHtmlContent, string RightHtmlContent) : IEmailBlock;
+```
+
+## Type Hierarchy
+
+```mermaid
+classDiagram
+    class IEmailBlock {
+        <<interface>>
+    }
+    class EmailDocument {
+        +string Subject
+        +string PreviewText
+        +string FromName
+        +string FromAddress
+        +IReadOnlyList~IEmailBlock~ Blocks
+    }
+    class HeroBlock {
+        +string ImageUrl
+        +string Headline
+    }
+    class TextBlock {
+        +string HtmlContent
+    }
+    class ButtonBlock {
+        +string Label
+        +string Url
+        +string BackgroundColor
+        +string TextColor
+    }
+    class ImageBlock {
+        +string ImageUrl
+        +string AltText
+    }
+    class DividerBlock
+    class TwoColumnBlock {
+        +string LeftHtmlContent
+        +string RightHtmlContent
+    }
+
+    IEmailBlock <|.. HeroBlock
+    IEmailBlock <|.. TextBlock
+    IEmailBlock <|.. ButtonBlock
+    IEmailBlock <|.. ImageBlock
+    IEmailBlock <|.. DividerBlock
+    IEmailBlock <|.. TwoColumnBlock
+    EmailDocument o-- IEmailBlock
+```
+
+## Related
+
+- [[architecture]] — where models fit in the system
+- [[html-generator]] — how models are rendered to HTML
+- [[api]] — how models are received over HTTP

--- a/docs/frontend.md
+++ b/docs/frontend.md
@@ -1,0 +1,118 @@
+---
+title: Frontend (React SPA)
+tags: [frontend, react, typescript]
+---
+
+# Frontend
+
+React 19 + Vite (TypeScript) SPA located in `EmailEditor/ClientApp/`.
+
+## Directory Structure
+
+```
+EmailEditor/ClientApp/
+├── src/
+│   ├── App.tsx                    ← Root component (placeholder)
+│   ├── components/
+│   │   ├── editor/                ← Canvas, palette, drag-drop
+│   │   ├── blocks/                ← One component per block type
+│   │   └── preview/               ← iframe HTML preview
+│   ├── api/                       ← fetch wrapper for /api/generate
+│   ├── index.css
+│   └── main.tsx
+├── public/
+├── index.html
+├── vite.config.ts
+├── tsconfig.json
+└── package.json
+```
+
+> [!note] Partially Implemented
+> Directory structure above reflects the intended design (#6, #7). Currently only `App.tsx` placeholder exists.
+
+## Key Dependencies
+
+| Package | Purpose |
+|---------|---------|
+| `@dnd-kit/core` | Drag-and-drop primitives |
+| `@dnd-kit/sortable` | Sortable list abstraction for the block canvas |
+| `@dnd-kit/utilities` | CSS transform helpers |
+| `quill` | Rich text editor (vanilla JS, wrapped with `useEffect`) |
+
+## Component Design
+
+### Editor Layout
+
+```
+┌────────────────────────────────────────────────┐
+│  Subject / Preview Text / From fields          │
+├──────────────┬─────────────────────────────────┤
+│  Block       │  Canvas (drag-drop)             │
+│  Palette     │  ┌──────────────────────────┐  │
+│              │  │  HeroBlock               │  │
+│  [Hero]      │  ├──────────────────────────┤  │
+│  [Text]      │  │  TextBlock (Quill)       │  │
+│  [Button]    │  ├──────────────────────────┤  │
+│  [Image]     │  │  ButtonBlock             │  │
+│  [Divider]   │  └──────────────────────────┘  │
+│  [2-Column]  │                                 │
+│              │  [Preview]  [Download HTML]     │
+└──────────────┴─────────────────────────────────┘
+```
+
+### Block Components (`src/components/blocks/`)
+
+Each block type has its own component with an inline editor:
+
+| Component | Editor UI |
+|-----------|-----------|
+| `HeroBlock` | Image URL input + headline text input |
+| `TextBlock` | Quill rich text editor |
+| `ButtonBlock` | Label input + URL input + color pickers |
+| `ImageBlock` | Image URL input + alt text input |
+| `DividerBlock` | No editor (style only) |
+| `TwoColumnBlock` | Two Quill editors side by side |
+
+### Quill Integration
+
+Quill is integrated as vanilla JS using `useEffect` and `useRef` (React 19 compatible):
+
+```tsx
+const editorRef = useRef<HTMLDivElement>(null);
+const quillRef = useRef<Quill | null>(null);
+
+useEffect(() => {
+  if (!editorRef.current || quillRef.current) return;
+  quillRef.current = new Quill(editorRef.current, { theme: 'snow' });
+  quillRef.current.on('text-change', () => {
+    onChange(quillRef.current!.root.innerHTML);
+  });
+}, []);
+```
+
+## API Integration (`src/api/`)
+
+```ts
+export async function generateHtml(doc: EmailDocument): Promise<string> {
+  const res = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(doc),
+  });
+  if (!res.ok) throw new Error(await res.text());
+  return res.text();
+}
+```
+
+## Dev Server
+
+```bash
+cd EmailEditor/ClientApp
+npm run dev   # Vite dev server on localhost:5173
+              # /api/* proxied to localhost:5261
+```
+
+## Related
+
+- [[architecture]] — how the SPA fits in the system
+- [[api]] — the endpoint the SPA calls

--- a/docs/html-generator.md
+++ b/docs/html-generator.md
@@ -1,0 +1,128 @@
+---
+title: HTML Generator
+tags: [backend, generator, email, csharp]
+---
+
+# HTML Generator
+
+> [!note] Not Yet Implemented
+> Tracked in [[https://github.com/shrinerp/email-editor/issues/3|#3]]. This document describes the intended design.
+
+## Overview
+
+`HtmlGeneratorService` (`EmailEditor/Services/HtmlGeneratorService.cs`) is the core of the application. It takes an `EmailDocument` and returns a complete, cross-email-client HTML string.
+
+```csharp
+public class HtmlGeneratorService
+{
+    public string Generate(EmailDocument doc): string;
+}
+```
+
+## Output Structure
+
+```html
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <!-- Preview text trick -->
+  <div style="display:none;max-height:0;overflow:hidden;">
+    {PreviewText}&#847; &zwnj; &nbsp; ...
+  </div>
+</head>
+<body>
+  <table width="100%" cellpadding="0" cellspacing="0" border="0">
+    <tr>
+      <td align="center">
+        <table width="600" cellpadding="0" cellspacing="0" border="0">
+          <!-- Blocks rendered here -->
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>
+```
+
+## Block Rendering Rules
+
+### Cross-Client Constraints
+
+> [!important] These rules apply to ALL block renderers
+> - No `flexbox` or `grid` — use `<table>` for every layout
+> - All CSS must be **inlined** — no `<style>` tags, no class names
+> - No `<button>` elements — use table cells with background colors
+> - Images must have explicit `width` and `height` attributes
+
+### HeroBlock
+
+```html
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td>
+      <img src="{ImageUrl}" width="600" style="display:block;width:100%;" alt="">
+      <p style="font-size:28px;font-weight:bold;margin:16px 0;">{Headline}</p>
+    </td>
+  </tr>
+</table>
+```
+
+### TextBlock
+
+Quill output is post-processed to inline all CSS before embedding. Wrapped in a padded table cell.
+
+> [!warning] Sanitization Required
+> `HtmlContent` from Quill must be HTML-sanitized before rendering to prevent XSS.
+
+### ButtonBlock
+
+Uses a VML fallback for Outlook — `<a>` with background color for modern clients, VML rect for Outlook.
+
+```html
+<!--[if mso]>
+<v:roundrect ...><v:textbox>
+<![endif]-->
+<a href="{Url}" style="background-color:{BackgroundColor};color:{TextColor};...">{Label}</a>
+<!--[if mso]></v:textbox></v:roundrect><![endif]-->
+```
+
+### TwoColumnBlock
+
+Two `<td>` cells, each `width="50%"`.
+
+```html
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td width="50%" valign="top">{LeftHtmlContent}</td>
+    <td width="50%" valign="top">{RightHtmlContent}</td>
+  </tr>
+</table>
+```
+
+### DividerBlock
+
+```html
+<table width="100%" cellpadding="0" cellspacing="0" border="0">
+  <tr>
+    <td style="padding:16px 0;">
+      <hr style="border:none;border-top:1px solid #e0e0e0;margin:0;">
+    </td>
+  </tr>
+</table>
+```
+
+## Testing Strategy
+
+Every block type is tested with xUnit. Tests assert:
+- Exact HTML structure (table layout, no divs for structure)
+- Inline styles present
+- Edge cases: empty content, special characters, missing optional fields
+
+See `EmailEditor.Tests/Services/HtmlGeneratorTests.cs` (created in #3).
+
+## Related
+
+- [[domain-model]] — input types
+- [[api]] — how the generator is invoked over HTTP

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,42 @@
+---
+title: Email Editor
+tags: [project, index]
+---
+
+# Email Editor
+
+A locally-hosted email editor that generates cross-email-client compatible HTML. Built with ASP.NET Core (backend) and React + Vite (frontend).
+
+## Quick Links
+
+- [[architecture]] — System design and layer overview
+- [[domain-model]] — Email block types and contracts
+- [[html-generator]] — Cross-client HTML generation rules
+- [[api]] — REST API reference
+- [[frontend]] — React SPA structure
+- [[dev-setup]] — Running the project locally
+
+## Project Status
+
+> [!note] In Progress
+> This project is actively being built. See the [issue tracker](https://github.com/shrinerp/email-editor/issues) for current status.
+
+| Issue | Title | Status |
+|-------|-------|--------|
+| #1 | tracking: Local Email HTML Editor | 🔵 Open |
+| #2 | feat(models): define email block domain model | ✅ Merged |
+| #3 | feat(generator): implement server-side HTML generator | ⚪ Pending |
+| #4 | feat(api): create POST /api/generate endpoint | ⚪ Pending |
+| #5 | infra(spa): scaffold React + Vite SPA | 🟡 PR Open |
+| #6 | feat(ui): build block builder UI with drag-drop canvas | ⚪ Pending |
+| #7 | feat(ui): implement preview and HTML download | ⚪ Pending |
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Backend | C# / ASP.NET Core (.NET 10) |
+| Frontend | React 19 + Vite (TypeScript) |
+| Drag-drop | dnd-kit |
+| Rich text | Quill (vanilla) |
+| Testing | xUnit |


### PR DESCRIPTION
## Summary
- Adds `docs/` directory formatted as an Obsidian vault
- 7 pages with wikilinks, frontmatter, callouts, and Mermaid diagrams

## Pages
- `index.md` — project overview and issue tracker status
- `architecture.md` — system design, data flow diagrams
- `domain-model.md` — all block types with class diagram
- `html-generator.md` — cross-client HTML rendering rules (design doc)
- `api.md` — REST API reference with request/response shapes
- `frontend.md` — React SPA structure and component design
- `dev-setup.md` — getting started guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)