### PR TITLE
feat(generator): implement server-side HTML generator (TDD)

### DIFF
--- a/EmailEditor.Tests/Services/HtmlGeneratorServiceTests.cs
+++ b/EmailEditor.Tests/Services/HtmlGeneratorServiceTests.cs
@@ -1,0 +1,233 @@
+using EmailEditor.Models;
+using EmailEditor.Services;
+
+namespace EmailEditor.Tests.Services;
+
+public class HtmlGeneratorServiceTests
+{
+    private readonly HtmlGeneratorService _sut = new();
+
+    private static EmailDocument DocWith(params IEmailBlock[] blocks) =>
+        new("Subject", "Preview text", "Sender", "sender@example.com", blocks.ToList().AsReadOnly());
+
+    // ── Document structure ────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_ReturnsDoctype()
+    {
+        var html = _sut.Generate(DocWith());
+        Assert.Contains("<!DOCTYPE html", html);
+    }
+
+    [Fact]
+    public void Generate_ReturnsHtmlHeadBody()
+    {
+        var html = _sut.Generate(DocWith());
+        Assert.Contains("<html", html);
+        Assert.Contains("<head>", html);
+        Assert.Contains("<body", html);
+    }
+
+    [Fact]
+    public void Generate_InlinesPreviewText()
+    {
+        var html = _sut.Generate(DocWith());
+        Assert.Contains("Preview text", html);
+        // Preview text trick: wrapped in a hidden div
+        Assert.Contains("display:none", html);
+        Assert.Contains("max-height:0", html);
+    }
+
+    [Fact]
+    public void Generate_UsesOuterCenteringTable()
+    {
+        var html = _sut.Generate(DocWith());
+        // Outer 100% table with centered alignment
+        Assert.Contains("width=\"100%\"", html);
+        Assert.Contains("align=\"center\"", html);
+    }
+
+    [Fact]
+    public void Generate_EmptyBlocksProducesValidDocument()
+    {
+        var html = _sut.Generate(DocWith());
+        Assert.Contains("</html>", html);
+    }
+
+    // ── HeroBlock ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_HeroBlock_ContainsImage()
+    {
+        var html = _sut.Generate(DocWith(new HeroBlock("https://img.url/banner.jpg", "Big Headline")));
+        Assert.Contains("https://img.url/banner.jpg", html);
+        Assert.Contains("<img", html);
+    }
+
+    [Fact]
+    public void Generate_HeroBlock_ContainsHeadline()
+    {
+        var html = _sut.Generate(DocWith(new HeroBlock("https://img.url/banner.jpg", "Big Headline")));
+        Assert.Contains("Big Headline", html);
+    }
+
+    [Fact]
+    public void Generate_HeroBlock_UsesTableLayout()
+    {
+        var html = _sut.Generate(DocWith(new HeroBlock("https://img.url/banner.jpg", "Headline")));
+        Assert.Contains("<table", html);
+        Assert.DoesNotContain("display:flex", html);
+        Assert.DoesNotContain("display:grid", html);
+    }
+
+    // ── TextBlock ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_TextBlock_ContainsHtmlContent()
+    {
+        var html = _sut.Generate(DocWith(new TextBlock("<p>Hello <strong>world</strong></p>")));
+        Assert.Contains("Hello", html);
+        Assert.Contains("world", html);
+    }
+
+    [Fact]
+    public void Generate_TextBlock_EmptyContent_DoesNotThrow()
+    {
+        var html = _sut.Generate(DocWith(new TextBlock("")));
+        Assert.Contains("</html>", html);
+    }
+
+    [Fact]
+    public void Generate_TextBlock_SpecialCharsPreserved()
+    {
+        var html = _sut.Generate(DocWith(new TextBlock("<p>Test &amp; more</p>")));
+        Assert.Contains("&amp;", html);
+    }
+
+    // ── ButtonBlock ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_ButtonBlock_ContainsLabel()
+    {
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click Me", "https://example.com")));
+        Assert.Contains("Click Me", html);
+    }
+
+    [Fact]
+    public void Generate_ButtonBlock_ContainsUrl()
+    {
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click", "https://example.com/landing")));
+        Assert.Contains("https://example.com/landing", html);
+    }
+
+    [Fact]
+    public void Generate_ButtonBlock_UsesBackgroundColor()
+    {
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click", "https://example.com", "#ff0000", "#ffffff")));
+        Assert.Contains("#ff0000", html);
+    }
+
+    [Fact]
+    public void Generate_ButtonBlock_UsesTextColor()
+    {
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click", "https://example.com", "#000000", "#00ff00")));
+        Assert.Contains("#00ff00", html);
+    }
+
+    [Fact]
+    public void Generate_ButtonBlock_NoButtonElement()
+    {
+        // Must use table cell, not <button>, for Outlook compatibility
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click", "https://example.com")));
+        Assert.DoesNotContain("<button", html);
+    }
+
+    [Fact]
+    public void Generate_ButtonBlock_UsesAnchorTag()
+    {
+        var html = _sut.Generate(DocWith(new ButtonBlock("Click", "https://example.com")));
+        Assert.Contains("<a ", html);
+        Assert.Contains("href=", html);
+    }
+
+    // ── ImageBlock ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_ImageBlock_ContainsSrc()
+    {
+        var html = _sut.Generate(DocWith(new ImageBlock("https://img.url/photo.jpg", "A photo")));
+        Assert.Contains("https://img.url/photo.jpg", html);
+    }
+
+    [Fact]
+    public void Generate_ImageBlock_ContainsAltText()
+    {
+        var html = _sut.Generate(DocWith(new ImageBlock("https://img.url/photo.jpg", "A photo")));
+        Assert.Contains("A photo", html);
+    }
+
+    [Fact]
+    public void Generate_ImageBlock_HasDisplayBlock()
+    {
+        var html = _sut.Generate(DocWith(new ImageBlock("https://img.url/photo.jpg", "alt")));
+        Assert.Contains("display:block", html);
+    }
+
+    // ── DividerBlock ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_DividerBlock_ContainsHr()
+    {
+        var html = _sut.Generate(DocWith(new DividerBlock()));
+        Assert.Contains("<hr", html);
+    }
+
+    [Fact]
+    public void Generate_DividerBlock_HasBorderNone()
+    {
+        var html = _sut.Generate(DocWith(new DividerBlock()));
+        Assert.Contains("border:none", html);
+    }
+
+    // ── TwoColumnBlock ────────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_TwoColumnBlock_ContainsBothColumns()
+    {
+        var html = _sut.Generate(DocWith(new TwoColumnBlock("<p>Left</p>", "<p>Right</p>")));
+        Assert.Contains("Left", html);
+        Assert.Contains("Right", html);
+    }
+
+    [Fact]
+    public void Generate_TwoColumnBlock_UsesFiftyPercentWidth()
+    {
+        var html = _sut.Generate(DocWith(new TwoColumnBlock("<p>L</p>", "<p>R</p>")));
+        Assert.Contains("50%", html);
+    }
+
+    [Fact]
+    public void Generate_TwoColumnBlock_UsesTableLayout()
+    {
+        var html = _sut.Generate(DocWith(new TwoColumnBlock("<p>L</p>", "<p>R</p>")));
+        Assert.Contains("<table", html);
+        Assert.DoesNotContain("display:flex", html);
+    }
+
+    // ── No style blocks ───────────────────────────────────────────────────
+
+    [Fact]
+    public void Generate_AllBlocks_NoStyleTags()
+    {
+        var html = _sut.Generate(DocWith(
+            new HeroBlock("https://img.url", "H"),
+            new TextBlock("<p>T</p>"),
+            new ButtonBlock("B", "https://url.com"),
+            new ImageBlock("https://img.url", "alt"),
+            new DividerBlock(),
+            new TwoColumnBlock("<p>L</p>", "<p>R</p>")
+        ));
+        Assert.DoesNotContain("<style>", html);
+        Assert.DoesNotContain("<style ", html);
+    }
+}

--- a/EmailEditor/Program.cs
+++ b/EmailEditor/Program.cs
@@ -1,4 +1,7 @@
+using EmailEditor.Services;
+
 var builder = WebApplication.CreateBuilder(args);
+builder.Services.AddSingleton<HtmlGeneratorService>();
 var app = builder.Build();
 
 app.UseDefaultFiles();

--- a/EmailEditor/Services/HtmlGeneratorService.cs
+++ b/EmailEditor/Services/HtmlGeneratorService.cs
@@ -1,0 +1,159 @@
+using System.Text;
+using EmailEditor.Models;
+
+namespace EmailEditor.Services;
+
+public class HtmlGeneratorService
+{
+    public string Generate(EmailDocument doc)
+    {
+        var sb = new StringBuilder();
+
+        sb.AppendLine("<!DOCTYPE html>");
+        sb.AppendLine("<html lang=\"en\">");
+        sb.AppendLine("<head>");
+        sb.AppendLine("<meta charset=\"UTF-8\">");
+        sb.AppendLine("<meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">");
+        sb.AppendLine("<meta http-equiv=\"X-UA-Compatible\" content=\"IE=edge\">");
+        sb.AppendLine("</head>");
+        sb.AppendLine("<body style=\"margin:0;padding:0;background-color:#f4f4f4;\">");
+
+        // Preview text trick — invisible text shown in inbox snippet
+        if (!string.IsNullOrEmpty(doc.PreviewText))
+        {
+            sb.AppendLine($"<div style=\"display:none;max-height:0;overflow:hidden;font-size:1px;color:#ffffff;\">{HtmlEncode(doc.PreviewText)}&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;&#847;&zwnj;&nbsp;</div>");
+        }
+
+        // Outer centering table
+        sb.AppendLine("<table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background-color:#f4f4f4;\">");
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td align=\"center\">");
+
+        // Inner content table (600px)
+        sb.AppendLine("<table width=\"600\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\" style=\"background-color:#ffffff;\">");
+
+        foreach (var block in doc.Blocks)
+        {
+            sb.AppendLine(RenderBlock(block));
+        }
+
+        sb.AppendLine("</table>");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        sb.AppendLine("</table>");
+
+        sb.AppendLine("</body>");
+        sb.AppendLine("</html>");
+
+        return sb.ToString();
+    }
+
+    private static string RenderBlock(IEmailBlock block) => block switch
+    {
+        HeroBlock hero         => RenderHero(hero),
+        TextBlock text         => RenderText(text),
+        ButtonBlock button     => RenderButton(button),
+        ImageBlock image       => RenderImage(image),
+        DividerBlock divider   => RenderDivider(divider),
+        TwoColumnBlock twoCol  => RenderTwoColumn(twoCol),
+        _                      => string.Empty
+    };
+
+    private static string RenderHero(HeroBlock block)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td style=\"padding:0;\">");
+        sb.AppendLine($"<table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\">");
+        sb.AppendLine("<tr>");
+        sb.AppendLine($"<td style=\"padding:0;\">");
+        sb.AppendLine($"<img src=\"{HtmlEncode(block.ImageUrl)}\" width=\"600\" style=\"display:block;width:100%;max-width:600px;\" alt=\"\">");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        sb.AppendLine("<tr>");
+        sb.AppendLine($"<td style=\"padding:24px 32px;font-family:Arial,sans-serif;font-size:28px;font-weight:bold;color:#1a1a1a;\">");
+        sb.AppendLine(HtmlEncode(block.Headline));
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string RenderText(TextBlock block)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine($"<td style=\"padding:16px 32px;font-family:Arial,sans-serif;font-size:16px;color:#333333;line-height:1.6;\">");
+        sb.AppendLine(block.HtmlContent); // Quill HTML — sanitized at API boundary
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string RenderButton(ButtonBlock block)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td style=\"padding:24px 32px;\" align=\"center\">");
+        sb.AppendLine("<table cellpadding=\"0\" cellspacing=\"0\" border=\"0\">");
+        sb.AppendLine("<tr>");
+        sb.AppendLine($"<td style=\"background-color:{HtmlEncode(block.BackgroundColor)};border-radius:4px;\" align=\"center\">");
+        sb.AppendLine($"<!--[if mso]><v:roundrect xmlns:v=\"urn:schemas-microsoft-com:vml\" href=\"{HtmlEncode(block.Url)}\" style=\"height:44px;v-text-anchor:middle;width:200px;\" arcsize=\"5%\" strokecolor=\"{HtmlEncode(block.BackgroundColor)}\" fillcolor=\"{HtmlEncode(block.BackgroundColor)}\"><v:textbox inset=\"0px,0px,0px,0px\"><center style=\"color:{HtmlEncode(block.TextColor)};font-family:Arial,sans-serif;font-size:16px;\">{HtmlEncode(block.Label)}</center></v:textbox></v:roundrect><![endif]-->");
+        sb.AppendLine($"<!--[if !mso]><!-->");
+        sb.AppendLine($"<a href=\"{HtmlEncode(block.Url)}\" style=\"display:inline-block;padding:12px 32px;background-color:{HtmlEncode(block.BackgroundColor)};color:{HtmlEncode(block.TextColor)};font-family:Arial,sans-serif;font-size:16px;font-weight:bold;text-decoration:none;border-radius:4px;\">{HtmlEncode(block.Label)}</a>");
+        sb.AppendLine("<!--<![endif]-->");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string RenderImage(ImageBlock block)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td style=\"padding:16px 32px;\">");
+        sb.AppendLine($"<img src=\"{HtmlEncode(block.ImageUrl)}\" alt=\"{HtmlEncode(block.AltText)}\" width=\"536\" style=\"display:block;width:100%;max-width:536px;\">");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string RenderDivider(DividerBlock _)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td style=\"padding:16px 32px;\">");
+        sb.AppendLine("<hr style=\"border:none;border-top:1px solid #e0e0e0;margin:0;\">");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string RenderTwoColumn(TwoColumnBlock block)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("<tr>");
+        sb.AppendLine("<td style=\"padding:16px 32px;\">");
+        sb.AppendLine("<table width=\"100%\" cellpadding=\"0\" cellspacing=\"0\" border=\"0\">");
+        sb.AppendLine("<tr>");
+        sb.AppendLine($"<td width=\"50%\" valign=\"top\" style=\"padding-right:8px;font-family:Arial,sans-serif;font-size:16px;color:#333333;line-height:1.6;\">");
+        sb.AppendLine(block.LeftHtmlContent);
+        sb.AppendLine("</td>");
+        sb.AppendLine($"<td width=\"50%\" valign=\"top\" style=\"padding-left:8px;font-family:Arial,sans-serif;font-size:16px;color:#333333;line-height:1.6;\">");
+        sb.AppendLine(block.RightHtmlContent);
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        sb.AppendLine("</table>");
+        sb.AppendLine("</td>");
+        sb.AppendLine("</tr>");
+        return sb.ToString();
+    }
+
+    private static string HtmlEncode(string value) =>
+        System.Net.WebUtility.HtmlEncode(value);
+}


### PR DESCRIPTION
## Description
Implements `HtmlGeneratorService` — the core of the email editor. Converts an `EmailDocument` into cross-email-client compatible HTML using table-based layout with inlined CSS.

## Changes
- `EmailEditor/Services/HtmlGeneratorService.cs` — full generator with all 6 block renderers
- `EmailEditor.Tests/Services/HtmlGeneratorServiceTests.cs` — 26 tests covering structure, all block types, edge cases
- `EmailEditor/Program.cs` — registers `HtmlGeneratorService` as singleton

## Testing
- [x] 37/37 tests passing (`dotnet test`)
- [x] No `<style>` tags in output
- [x] No flexbox or grid layout
- [x] VML conditional comments for Outlook button backgrounds
- [x] Preview text trick (invisible hidden div)

## Checklist
- [x] Architecture conventions respected
- [x] TDD: tests written before implementation
- [x] All tests pass locally
- [x] Service registered in DI

Closes #3
Part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)