### PR TITLE
feat(api): create POST /api/generate endpoint

### DIFF
--- a/EmailEditor.Tests/Api/GenerateEndpointTests.cs
+++ b/EmailEditor.Tests/Api/GenerateEndpointTests.cs
@@ -1,0 +1,105 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using Microsoft.AspNetCore.Mvc.Testing;
+
+namespace EmailEditor.Tests.Api;
+
+public class GenerateEndpointTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly HttpClient _client;
+
+    public GenerateEndpointTests(WebApplicationFactory<Program> factory)
+    {
+        _client = factory.CreateClient();
+    }
+
+    private static object FullDocument() => new
+    {
+        subject = "Test Subject",
+        previewText = "Preview snippet",
+        fromName = "Sender",
+        fromAddress = "sender@example.com",
+        blocks = new object[]
+        {
+            new { type = "hero", imageUrl = "https://img.url/banner.jpg", headline = "Hello" },
+            new { type = "text", htmlContent = "<p>Body text</p>" },
+            new { type = "button", label = "Click", url = "https://example.com", backgroundColor = "#000000", textColor = "#ffffff" },
+            new { type = "image", imageUrl = "https://img.url/photo.jpg", altText = "Photo" },
+            new { type = "divider" },
+            new { type = "twoColumn", leftHtmlContent = "<p>Left</p>", rightHtmlContent = "<p>Right</p>" },
+        }
+    };
+
+    [Fact]
+    public async Task PostGenerate_WithValidDocument_Returns200()
+    {
+        var response = await _client.PostAsJsonAsync("/api/generate", FullDocument());
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostGenerate_WithValidDocument_ReturnsHtmlContentType()
+    {
+        var response = await _client.PostAsJsonAsync("/api/generate", FullDocument());
+        Assert.Equal("text/html", response.Content.Headers.ContentType?.MediaType);
+    }
+
+    [Fact]
+    public async Task PostGenerate_WithValidDocument_ReturnsHtmlDoctype()
+    {
+        var response = await _client.PostAsJsonAsync("/api/generate", FullDocument());
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("<!DOCTYPE html", html);
+    }
+
+    [Fact]
+    public async Task PostGenerate_WithValidDocument_RendersAllBlocks()
+    {
+        var response = await _client.PostAsJsonAsync("/api/generate", FullDocument());
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.Contains("Hello", html);          // hero headline
+        Assert.Contains("Body text", html);       // text block
+        Assert.Contains("Click", html);           // button label
+        Assert.Contains("Photo", html);           // image alt
+        Assert.Contains("<hr", html);             // divider
+        Assert.Contains("Left", html);            // two-column
+        Assert.Contains("Right", html);
+    }
+
+    [Fact]
+    public async Task PostGenerate_WithEmptyBody_Returns400()
+    {
+        var response = await _client.PostAsync("/api/generate",
+            new StringContent("", System.Text.Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostGenerate_WithMalformedJson_Returns400()
+    {
+        var response = await _client.PostAsync("/api/generate",
+            new StringContent("{ not valid json }", System.Text.Encoding.UTF8, "application/json"));
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostGenerate_ScriptInTextBlock_IsSanitized()
+    {
+        var doc = new
+        {
+            subject = "S",
+            previewText = "P",
+            fromName = "F",
+            fromAddress = "f@f.com",
+            blocks = new object[]
+            {
+                new { type = "text", htmlContent = "<script>alert('xss')</script><p>Safe</p>" }
+            }
+        };
+        var response = await _client.PostAsJsonAsync("/api/generate", doc);
+        var html = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("<script>", html);
+        Assert.Contains("Safe", html);
+    }
+}

--- a/EmailEditor.Tests/EmailEditor.Tests.csproj
+++ b/EmailEditor.Tests/EmailEditor.Tests.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4" />

--- a/EmailEditor/Api/EmailDocumentDto.cs
+++ b/EmailEditor/Api/EmailDocumentDto.cs
@@ -1,0 +1,75 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using EmailEditor.Models;
+
+namespace EmailEditor.Api;
+
+// DTOs for JSON deserialization with polymorphic block types
+
+public record EmailDocumentDto(
+    string Subject,
+    string PreviewText,
+    string FromName,
+    string FromAddress,
+    List<JsonElement> Blocks
+);
+
+public static class EmailDocumentDtoExtensions
+{
+    public static EmailDocument ToEmailDocument(this EmailDocumentDto dto, Func<string, string> sanitize)
+    {
+        var blocks = dto.Blocks
+            .Select(b => DeserializeBlock(b, sanitize))
+            .Where(b => b is not null)
+            .Cast<IEmailBlock>()
+            .ToList()
+            .AsReadOnly();
+
+        return new EmailDocument(
+            dto.Subject ?? "",
+            dto.PreviewText ?? "",
+            dto.FromName ?? "",
+            dto.FromAddress ?? "",
+            blocks
+        );
+    }
+
+    private static IEmailBlock? DeserializeBlock(JsonElement el, Func<string, string> sanitize)
+    {
+        var type = el.TryGetProperty("type", out var t) ? t.GetString() : null;
+
+        return type switch
+        {
+            "hero" => new HeroBlock(
+                GetString(el, "imageUrl"),
+                GetString(el, "headline")),
+
+            "text" => new TextBlock(
+                sanitize(GetString(el, "htmlContent"))),
+
+            "button" => new ButtonBlock(
+                GetString(el, "label"),
+                GetString(el, "url"),
+                GetStringOrDefault(el, "backgroundColor", "#000000"),
+                GetStringOrDefault(el, "textColor", "#ffffff")),
+
+            "image" => new ImageBlock(
+                GetString(el, "imageUrl"),
+                GetString(el, "altText")),
+
+            "divider" => new DividerBlock(),
+
+            "twoColumn" => new TwoColumnBlock(
+                sanitize(GetString(el, "leftHtmlContent")),
+                sanitize(GetString(el, "rightHtmlContent"))),
+
+            _ => null
+        };
+    }
+
+    private static string GetString(JsonElement el, string prop) =>
+        el.TryGetProperty(prop, out var v) ? v.GetString() ?? "" : "";
+
+    private static string GetStringOrDefault(JsonElement el, string prop, string defaultValue) =>
+        el.TryGetProperty(prop, out var v) ? v.GetString() ?? defaultValue : defaultValue;
+}

--- a/EmailEditor/EmailEditor.csproj
+++ b/EmailEditor/EmailEditor.csproj
@@ -6,4 +6,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="HtmlSanitizer" Version="9.0.892" />
+  </ItemGroup>
+
 </Project>

--- a/EmailEditor/Program.cs
+++ b/EmailEditor/Program.cs
@@ -1,13 +1,42 @@
+using System.Text.Json;
+using EmailEditor.Api;
 using EmailEditor.Services;
+using Ganss.Xss;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddSingleton<HtmlGeneratorService>();
+builder.Services.AddSingleton<HtmlSanitizer>();
 var app = builder.Build();
 
 app.UseDefaultFiles();
 app.UseStaticFiles();
 
+// POST /api/generate — accepts EmailDocument JSON, returns cross-client HTML
+app.MapPost("/api/generate", (HttpContext ctx, HtmlGeneratorService generator, HtmlSanitizer sanitizer) =>
+{
+    EmailDocumentDto? dto;
+    try
+    {
+        dto = ctx.Request.ReadFromJsonAsync<EmailDocumentDto>().GetAwaiter().GetResult();
+    }
+    catch
+    {
+        return Results.BadRequest("Invalid JSON");
+    }
+
+    if (dto is null)
+        return Results.BadRequest("Request body is required");
+
+    var doc = dto.ToEmailDocument(html => sanitizer.Sanitize(html));
+    var html = generator.Generate(doc);
+
+    return Results.Content(html, "text/html");
+});
+
 // SPA fallback: serve index.html for non-API routes
 app.MapFallbackToFile("index.html");
 
 app.Run();
+
+// Required for WebApplicationFactory in integration tests
+public partial class Program { }


### PR DESCRIPTION
## Description
Exposes `HtmlGeneratorService` over HTTP. The React SPA POSTs an `EmailDocument` JSON body and receives cross-client HTML in return.

## Changes
- `EmailEditor/Api/EmailDocumentDto.cs` — polymorphic block deserialization via `JsonElement`
- `EmailEditor/Program.cs` — `POST /api/generate` minimal API endpoint + `HtmlSanitizer` DI
- `EmailEditor.Tests/Api/GenerateEndpointTests.cs` — 7 integration tests via `WebApplicationFactory`

## Testing
- [x] 44/44 tests passing
- [x] 400 returned for empty/malformed JSON
- [x] `<script>` tags stripped from htmlContent before generation
- [x] Response `Content-Type: text/html`

## Checklist
- [x] Architecture conventions respected
- [x] TDD: tests written before implementation
- [x] All tests pass locally
- [x] XSS sanitization at API boundary

Closes #4
Part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)