### PR TITLE
feat(ui): build block builder UI with drag-drop canvas

### DIFF
--- a/EmailEditor/ClientApp/src/App.tsx
+++ b/EmailEditor/ClientApp/src/App.tsx
@@ -1,3 +1,49 @@
+import { useState } from 'react';
+import { BlockPalette } from './components/editor/BlockPalette';
+import { BlockCanvas } from './components/editor/BlockCanvas';
+import { MetadataForm } from './components/editor/MetadataForm';
+import type { EmailBlock, BlockType } from './types/blocks';
+import { createBlock } from './types/blocks';
+
+interface Metadata {
+  subject: string;
+  previewText: string;
+  fromName: string;
+  fromAddress: string;
+}
+
 export default function App() {
-  return <h1>Email Editor</h1>;
+  const [metadata, setMetadata] = useState<Metadata>({
+    subject: '',
+    previewText: '',
+    fromName: '',
+    fromAddress: '',
+  });
+  const [blocks, setBlocks] = useState<EmailBlock[]>([]);
+
+  function addBlock(type: BlockType) {
+    setBlocks(prev => [...prev, createBlock(type)]);
+  }
+
+  return (
+    <div style={{ fontFamily: 'system-ui, sans-serif', minHeight: '100vh', background: '#f0f0f0' }}>
+      <header style={{
+        background: '#1a1a1a',
+        color: '#fff',
+        padding: '12px 24px',
+        display: 'flex',
+        alignItems: 'center',
+      }}>
+        <span style={{ fontWeight: 700, fontSize: 18 }}>✉️ Email Editor</span>
+      </header>
+
+      <div style={{ display: 'flex', gap: 16, padding: 16, maxWidth: 1200, margin: '0 auto' }}>
+        <BlockPalette onAdd={addBlock} />
+        <div style={{ flex: 1 }}>
+          <MetadataForm metadata={metadata} onChange={setMetadata} />
+          <BlockCanvas blocks={blocks} onBlocksChange={setBlocks} />
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/EmailEditor/ClientApp/src/components/blocks/ButtonBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/ButtonBlockEditor.tsx
@@ -1,0 +1,59 @@
+import type { ButtonBlock } from '../../types/blocks';
+
+interface Props {
+  block: ButtonBlock;
+  onChange: (updated: ButtonBlock) => void;
+}
+
+export function ButtonBlockEditor({ block, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <label style={{ fontWeight: 600 }}>Button / CTA</label>
+      <input
+        type="text"
+        placeholder="Button label"
+        value={block.label}
+        onChange={e => onChange({ ...block, label: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      <input
+        type="text"
+        placeholder="URL (https://...)"
+        value={block.url}
+        onChange={e => onChange({ ...block, url: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      <div style={{ display: 'flex', gap: 12, alignItems: 'center' }}>
+        <label style={{ fontSize: 13 }}>
+          Background
+          <input type="color" value={block.backgroundColor}
+            onChange={e => onChange({ ...block, backgroundColor: e.target.value })}
+            style={{ marginLeft: 6 }} />
+        </label>
+        <label style={{ fontSize: 13 }}>
+          Text
+          <input type="color" value={block.textColor}
+            onChange={e => onChange({ ...block, textColor: e.target.value })}
+            style={{ marginLeft: 6 }} />
+        </label>
+      </div>
+      <div style={{ marginTop: 4 }}>
+        <a
+          href={block.url || '#'}
+          style={{
+            display: 'inline-block',
+            padding: '10px 24px',
+            backgroundColor: block.backgroundColor,
+            color: block.textColor,
+            borderRadius: 4,
+            textDecoration: 'none',
+            fontWeight: 600,
+            fontSize: 14,
+          }}
+        >
+          {block.label || 'Button'}
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/blocks/DividerBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/DividerBlockEditor.tsx
@@ -1,0 +1,8 @@
+export function DividerBlockEditor() {
+  return (
+    <div>
+      <label style={{ fontWeight: 600, display: 'block', marginBottom: 8 }}>Divider</label>
+      <hr style={{ border: 'none', borderTop: '1px solid #e0e0e0', margin: 0 }} />
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
@@ -1,0 +1,31 @@
+import type { HeroBlock } from '../../types/blocks';
+
+interface Props {
+  block: HeroBlock;
+  onChange: (updated: HeroBlock) => void;
+}
+
+export function HeroBlockEditor({ block, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <label style={{ fontWeight: 600 }}>Hero Block</label>
+      <input
+        type="text"
+        placeholder="Image URL"
+        value={block.imageUrl}
+        onChange={e => onChange({ ...block, imageUrl: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      <input
+        type="text"
+        placeholder="Headline"
+        value={block.headline}
+        onChange={e => onChange({ ...block, headline: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      {block.imageUrl && (
+        <img src={block.imageUrl} alt="preview" style={{ maxWidth: '100%', maxHeight: 120, objectFit: 'cover', borderRadius: 4 }} />
+      )}
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/blocks/ImageBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/ImageBlockEditor.tsx
@@ -1,0 +1,31 @@
+import type { ImageBlock } from '../../types/blocks';
+
+interface Props {
+  block: ImageBlock;
+  onChange: (updated: ImageBlock) => void;
+}
+
+export function ImageBlockEditor({ block, onChange }: Props) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <label style={{ fontWeight: 600 }}>Image Block</label>
+      <input
+        type="text"
+        placeholder="Image URL"
+        value={block.imageUrl}
+        onChange={e => onChange({ ...block, imageUrl: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      <input
+        type="text"
+        placeholder="Alt text"
+        value={block.altText}
+        onChange={e => onChange({ ...block, altText: e.target.value })}
+        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
+      />
+      {block.imageUrl && (
+        <img src={block.imageUrl} alt={block.altText} style={{ maxWidth: '100%', maxHeight: 120, objectFit: 'cover', borderRadius: 4 }} />
+      )}
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/blocks/TextBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/TextBlockEditor.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useRef } from 'react';
+import Quill from 'quill';
+import 'quill/dist/quill.snow.css';
+import type { TextBlock } from '../../types/blocks';
+
+interface Props {
+  block: TextBlock;
+  onChange: (updated: TextBlock) => void;
+}
+
+export function TextBlockEditor({ block, onChange }: Props) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const quillRef = useRef<Quill | null>(null);
+  const blockIdRef = useRef(block.id);
+
+  useEffect(() => {
+    if (!editorRef.current || quillRef.current) return;
+    quillRef.current = new Quill(editorRef.current, {
+      theme: 'snow',
+      modules: { toolbar: [['bold', 'italic', 'underline'], ['link'], [{ color: [] }]] },
+    });
+    if (block.htmlContent) {
+      quillRef.current.clipboard.dangerouslyPasteHTML(block.htmlContent);
+    }
+    quillRef.current.on('text-change', () => {
+      onChange({ ...block, id: blockIdRef.current, htmlContent: quillRef.current!.root.innerHTML });
+    });
+  }, []);
+
+  // Update blockIdRef when block.id changes (shouldn't normally happen)
+  useEffect(() => { blockIdRef.current = block.id; }, [block.id]);
+
+  return (
+    <div>
+      <label style={{ fontWeight: 600, display: 'block', marginBottom: 6 }}>Text Block</label>
+      <div ref={editorRef} style={{ minHeight: 100 }} />
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/blocks/TwoColumnBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/TwoColumnBlockEditor.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from 'react';
+import Quill from 'quill';
+import 'quill/dist/quill.snow.css';
+import type { TwoColumnBlock } from '../../types/blocks';
+
+interface Props {
+  block: TwoColumnBlock;
+  onChange: (updated: TwoColumnBlock) => void;
+}
+
+function QuillEditor({ value, onChangeHtml }: { value: string; onChangeHtml: (html: string) => void }) {
+  const editorRef = useRef<HTMLDivElement>(null);
+  const quillRef = useRef<Quill | null>(null);
+
+  useEffect(() => {
+    if (!editorRef.current || quillRef.current) return;
+    quillRef.current = new Quill(editorRef.current, {
+      theme: 'snow',
+      modules: { toolbar: [['bold', 'italic'], ['link']] },
+    });
+    if (value) quillRef.current.clipboard.dangerouslyPasteHTML(value);
+    quillRef.current.on('text-change', () => {
+      onChangeHtml(quillRef.current!.root.innerHTML);
+    });
+  }, []);
+
+  return <div ref={editorRef} style={{ minHeight: 80 }} />;
+}
+
+export function TwoColumnBlockEditor({ block, onChange }: Props) {
+  return (
+    <div>
+      <label style={{ fontWeight: 600, display: 'block', marginBottom: 8 }}>Two Columns</label>
+      <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+        <div>
+          <div style={{ fontSize: 12, color: '#666', marginBottom: 4 }}>Left</div>
+          <QuillEditor
+            value={block.leftHtmlContent}
+            onChangeHtml={html => onChange({ ...block, leftHtmlContent: html })}
+          />
+        </div>
+        <div>
+          <div style={{ fontSize: 12, color: '#666', marginBottom: 4 }}>Right</div>
+          <QuillEditor
+            value={block.rightHtmlContent}
+            onChangeHtml={html => onChange({ ...block, rightHtmlContent: html })}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/editor/BlockCanvas.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/BlockCanvas.tsx
@@ -1,0 +1,141 @@
+import {
+  DndContext,
+  closestCenter,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+  arrayMove,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { EmailBlock } from '../../types/blocks';
+import { HeroBlockEditor } from '../blocks/HeroBlockEditor';
+import { TextBlockEditor } from '../blocks/TextBlockEditor';
+import { ButtonBlockEditor } from '../blocks/ButtonBlockEditor';
+import { ImageBlockEditor } from '../blocks/ImageBlockEditor';
+import { DividerBlockEditor } from '../blocks/DividerBlockEditor';
+import { TwoColumnBlockEditor } from '../blocks/TwoColumnBlockEditor';
+
+function BlockEditor({ block, onChange }: { block: EmailBlock; onChange: (b: EmailBlock) => void }) {
+  switch (block.type) {
+    case 'hero':      return <HeroBlockEditor block={block} onChange={onChange} />;
+    case 'text':      return <TextBlockEditor block={block} onChange={onChange} />;
+    case 'button':    return <ButtonBlockEditor block={block} onChange={onChange} />;
+    case 'image':     return <ImageBlockEditor block={block} onChange={onChange} />;
+    case 'divider':   return <DividerBlockEditor />;
+    case 'twoColumn': return <TwoColumnBlockEditor block={block} onChange={onChange} />;
+  }
+}
+
+function SortableBlock({
+  block,
+  onChange,
+  onDelete,
+}: {
+  block: EmailBlock;
+  onChange: (b: EmailBlock) => void;
+  onDelete: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: block.id });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style}>
+      <div style={{
+        background: '#fff',
+        border: '1px solid #e0e0e0',
+        borderRadius: 8,
+        padding: 16,
+        marginBottom: 8,
+      }}>
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: 12 }}>
+          <span
+            {...attributes}
+            {...listeners}
+            style={{ cursor: 'grab', color: '#aaa', marginRight: 10, fontSize: 18, lineHeight: 1 }}
+            title="Drag to reorder"
+          >
+            ⠿
+          </span>
+          <div style={{ flex: 1 }} />
+          <button
+            onClick={onDelete}
+            style={{ background: 'none', border: 'none', cursor: 'pointer', color: '#999', fontSize: 18, lineHeight: 1, padding: 0 }}
+            title="Delete block"
+          >
+            ✕
+          </button>
+        </div>
+        <BlockEditor block={block} onChange={onChange} />
+      </div>
+    </div>
+  );
+}
+
+interface Props {
+  blocks: EmailBlock[];
+  onBlocksChange: (blocks: EmailBlock[]) => void;
+}
+
+export function BlockCanvas({ blocks, onBlocksChange }: Props) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (over && active.id !== over.id) {
+      const oldIndex = blocks.findIndex(b => b.id === active.id);
+      const newIndex = blocks.findIndex(b => b.id === over.id);
+      onBlocksChange(arrayMove(blocks, oldIndex, newIndex));
+    }
+  }
+
+  if (blocks.length === 0) {
+    return (
+      <div style={{
+        flex: 1,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        color: '#aaa',
+        border: '2px dashed #e0e0e0',
+        borderRadius: 8,
+        minHeight: 200,
+        fontSize: 14,
+      }}>
+        Add a block from the palette to get started
+      </div>
+    );
+  }
+
+  return (
+    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+      <SortableContext items={blocks.map(b => b.id)} strategy={verticalListSortingStrategy}>
+        <div style={{ flex: 1 }}>
+          {blocks.map(block => (
+            <SortableBlock
+              key={block.id}
+              block={block}
+              onChange={updated => onBlocksChange(blocks.map(b => b.id === updated.id ? updated : b))}
+              onDelete={() => onBlocksChange(blocks.filter(b => b.id !== block.id))}
+            />
+          ))}
+        </div>
+      </SortableContext>
+    </DndContext>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
@@ -1,0 +1,57 @@
+import type { BlockType } from '../../types/blocks';
+
+const BLOCK_TYPES: { type: BlockType; label: string; icon: string }[] = [
+  { type: 'hero',      label: 'Hero',       icon: '🖼️' },
+  { type: 'text',      label: 'Text',       icon: '📝' },
+  { type: 'button',    label: 'Button',     icon: '🔘' },
+  { type: 'image',     label: 'Image',      icon: '📷' },
+  { type: 'divider',   label: 'Divider',    icon: '➖' },
+  { type: 'twoColumn', label: '2 Columns',  icon: '⬜' },
+];
+
+interface Props {
+  onAdd: (type: BlockType) => void;
+}
+
+export function BlockPalette({ onAdd }: Props) {
+  return (
+    <aside style={{
+      width: 160,
+      flexShrink: 0,
+      background: '#f8f8f8',
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      padding: 16,
+    }}>
+      <div style={{ fontWeight: 700, fontSize: 13, color: '#555', marginBottom: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+        Blocks
+      </div>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+        {BLOCK_TYPES.map(({ type, label, icon }) => (
+          <button
+            key={type}
+            onClick={() => onAdd(type)}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 8,
+              padding: '8px 10px',
+              background: '#fff',
+              border: '1px solid #ddd',
+              borderRadius: 6,
+              cursor: 'pointer',
+              fontSize: 13,
+              textAlign: 'left',
+              transition: 'background 0.15s',
+            }}
+            onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
+            onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+          >
+            <span>{icon}</span>
+            <span>{label}</span>
+          </button>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/EmailEditor/ClientApp/src/components/editor/MetadataForm.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/MetadataForm.tsx
@@ -1,0 +1,64 @@
+interface Metadata {
+  subject: string;
+  previewText: string;
+  fromName: string;
+  fromAddress: string;
+}
+
+interface Props {
+  metadata: Metadata;
+  onChange: (updated: Metadata) => void;
+}
+
+const fieldStyle = {
+  padding: '6px 8px',
+  border: '1px solid #ccc',
+  borderRadius: 4,
+  fontSize: 14,
+  width: '100%',
+  boxSizing: 'border-box' as const,
+};
+
+const labelStyle = {
+  fontSize: 12,
+  fontWeight: 600,
+  color: '#555',
+  display: 'block',
+  marginBottom: 4,
+};
+
+export function MetadataForm({ metadata, onChange }: Props) {
+  return (
+    <div style={{
+      background: '#f8f8f8',
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      padding: 16,
+      marginBottom: 16,
+      display: 'grid',
+      gridTemplateColumns: '1fr 1fr',
+      gap: 12,
+    }}>
+      <div>
+        <label style={labelStyle}>Subject</label>
+        <input style={fieldStyle} type="text" placeholder="Email subject" value={metadata.subject}
+          onChange={e => onChange({ ...metadata, subject: e.target.value })} />
+      </div>
+      <div>
+        <label style={labelStyle}>Preview Text</label>
+        <input style={fieldStyle} type="text" placeholder="Inbox snippet..." value={metadata.previewText}
+          onChange={e => onChange({ ...metadata, previewText: e.target.value })} />
+      </div>
+      <div>
+        <label style={labelStyle}>From Name</label>
+        <input style={fieldStyle} type="text" placeholder="Sender name" value={metadata.fromName}
+          onChange={e => onChange({ ...metadata, fromName: e.target.value })} />
+      </div>
+      <div>
+        <label style={labelStyle}>From Address</label>
+        <input style={fieldStyle} type="email" placeholder="sender@example.com" value={metadata.fromAddress}
+          onChange={e => onChange({ ...metadata, fromAddress: e.target.value })} />
+      </div>
+    </div>
+  );
+}

--- a/EmailEditor/ClientApp/src/types/blocks.ts
+++ b/EmailEditor/ClientApp/src/types/blocks.ts
@@ -1,0 +1,69 @@
+export type BlockType = 'hero' | 'text' | 'button' | 'image' | 'divider' | 'twoColumn';
+
+export interface BaseBlock {
+  id: string;
+  type: BlockType;
+}
+
+export interface HeroBlock extends BaseBlock {
+  type: 'hero';
+  imageUrl: string;
+  headline: string;
+}
+
+export interface TextBlock extends BaseBlock {
+  type: 'text';
+  htmlContent: string;
+}
+
+export interface ButtonBlock extends BaseBlock {
+  type: 'button';
+  label: string;
+  url: string;
+  backgroundColor: string;
+  textColor: string;
+}
+
+export interface ImageBlock extends BaseBlock {
+  type: 'image';
+  imageUrl: string;
+  altText: string;
+}
+
+export interface DividerBlock extends BaseBlock {
+  type: 'divider';
+}
+
+export interface TwoColumnBlock extends BaseBlock {
+  type: 'twoColumn';
+  leftHtmlContent: string;
+  rightHtmlContent: string;
+}
+
+export type EmailBlock =
+  | HeroBlock
+  | TextBlock
+  | ButtonBlock
+  | ImageBlock
+  | DividerBlock
+  | TwoColumnBlock;
+
+export interface EmailDocument {
+  subject: string;
+  previewText: string;
+  fromName: string;
+  fromAddress: string;
+  blocks: EmailBlock[];
+}
+
+export function createBlock(type: BlockType): EmailBlock {
+  const id = crypto.randomUUID();
+  switch (type) {
+    case 'hero':       return { id, type, imageUrl: '', headline: '' };
+    case 'text':       return { id, type, htmlContent: '' };
+    case 'button':     return { id, type, label: 'Click here', url: '', backgroundColor: '#1a1a1a', textColor: '#ffffff' };
+    case 'image':      return { id, type, imageUrl: '', altText: '' };
+    case 'divider':    return { id, type };
+    case 'twoColumn':  return { id, type, leftHtmlContent: '', rightHtmlContent: '' };
+  }
+}


### PR DESCRIPTION
## Description
Implements the full block builder UI: palette, sortable canvas, metadata form, and inline editors for all 6 block types.

## Changes
- `src/types/blocks.ts` — TypeScript block types + `createBlock` factory
- `src/components/editor/BlockPalette.tsx` — click-to-add block palette
- `src/components/editor/BlockCanvas.tsx` — dnd-kit sortable canvas with delete
- `src/components/editor/MetadataForm.tsx` — Subject, Preview Text, From fields
- `src/components/blocks/*` — inline editors for Hero, Text, Button, Image, Divider, TwoColumn
- `src/App.tsx` — wires everything together

## Testing
- [x] TypeScript build passes (`npm run build`)
- [x] 44/44 .NET tests still passing
- [ ] Manual: add/reorder/delete blocks, edit each type

Closes #6
Part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)