### PR TITLE
feat(ui): implement preview and HTML download

### DIFF
--- a/EmailEditor/ClientApp/src/App.tsx
+++ b/EmailEditor/ClientApp/src/App.tsx
@@ -2,8 +2,10 @@ import { useState } from 'react';
 import { BlockPalette } from './components/editor/BlockPalette';
 import { BlockCanvas } from './components/editor/BlockCanvas';
 import { MetadataForm } from './components/editor/MetadataForm';
+import { PreviewPanel } from './components/preview/PreviewPanel';
 import type { EmailBlock, BlockType } from './types/blocks';
 import { createBlock } from './types/blocks';
+import { generateHtml } from './api/generate';
 
 interface Metadata {
   subject: string;
@@ -11,6 +13,16 @@ interface Metadata {
   fromName: string;
   fromAddress: string;
 }
+
+const btnBase: React.CSSProperties = {
+  padding: '8px 20px',
+  borderRadius: 6,
+  border: 'none',
+  cursor: 'pointer',
+  fontWeight: 600,
+  fontSize: 14,
+  transition: 'opacity 0.15s',
+};
 
 export default function App() {
   const [metadata, setMetadata] = useState<Metadata>({
@@ -20,9 +32,48 @@ export default function App() {
     fromAddress: '',
   });
   const [blocks, setBlocks] = useState<EmailBlock[]>([]);
+  const [previewHtml, setPreviewHtml] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   function addBlock(type: BlockType) {
     setBlocks(prev => [...prev, createBlock(type)]);
+  }
+
+  function buildDocument() {
+    return { ...metadata, blocks };
+  }
+
+  async function handlePreview() {
+    setLoading(true);
+    setError(null);
+    try {
+      const html = await generateHtml(buildDocument());
+      setPreviewHtml(html);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function handleDownload() {
+    setLoading(true);
+    setError(null);
+    try {
+      const html = await generateHtml(buildDocument());
+      const blob = new Blob([html], { type: 'text/html' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `${metadata.subject || 'email'}.html`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Unknown error');
+    } finally {
+      setLoading(false);
+    }
   }
 
   return (
@@ -33,15 +84,37 @@ export default function App() {
         padding: '12px 24px',
         display: 'flex',
         alignItems: 'center',
+        gap: 16,
       }}>
-        <span style={{ fontWeight: 700, fontSize: 18 }}>✉️ Email Editor</span>
+        <span style={{ fontWeight: 700, fontSize: 18, flex: 1 }}>✉️ Email Editor</span>
+        <button
+          onClick={handlePreview}
+          disabled={loading}
+          style={{ ...btnBase, background: '#3b82f6', color: '#fff', opacity: loading ? 0.6 : 1 }}
+        >
+          {loading ? 'Loading…' : '👁 Preview'}
+        </button>
+        <button
+          onClick={handleDownload}
+          disabled={loading}
+          style={{ ...btnBase, background: '#22c55e', color: '#fff', opacity: loading ? 0.6 : 1 }}
+        >
+          {loading ? 'Loading…' : '⬇ Download HTML'}
+        </button>
       </header>
+
+      {error && (
+        <div style={{ background: '#fee2e2', color: '#991b1b', padding: '10px 24px', fontSize: 14 }}>
+          {error}
+        </div>
+      )}
 
       <div style={{ display: 'flex', gap: 16, padding: 16, maxWidth: 1200, margin: '0 auto' }}>
         <BlockPalette onAdd={addBlock} />
         <div style={{ flex: 1 }}>
           <MetadataForm metadata={metadata} onChange={setMetadata} />
           <BlockCanvas blocks={blocks} onBlocksChange={setBlocks} />
+          <PreviewPanel html={previewHtml} />
         </div>
       </div>
     </div>

--- a/EmailEditor/ClientApp/src/api/generate.ts
+++ b/EmailEditor/ClientApp/src/api/generate.ts
@@ -1,0 +1,16 @@
+import type { EmailDocument } from '../types/blocks';
+
+export async function generateHtml(doc: EmailDocument): Promise<string> {
+  const response = await fetch('/api/generate', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(doc),
+  });
+
+  if (!response.ok) {
+    const text = await response.text();
+    throw new Error(`Generation failed (${response.status}): ${text}`);
+  }
+
+  return response.text();
+}

--- a/EmailEditor/ClientApp/src/components/preview/PreviewPanel.tsx
+++ b/EmailEditor/ClientApp/src/components/preview/PreviewPanel.tsx
@@ -1,0 +1,36 @@
+interface Props {
+  html: string | null;
+}
+
+export function PreviewPanel({ html }: Props) {
+  if (!html) return null;
+
+  return (
+    <div style={{
+      marginTop: 16,
+      border: '1px solid #e0e0e0',
+      borderRadius: 8,
+      overflow: 'hidden',
+      background: '#fff',
+    }}>
+      <div style={{
+        padding: '8px 16px',
+        background: '#f8f8f8',
+        borderBottom: '1px solid #e0e0e0',
+        fontSize: 12,
+        fontWeight: 600,
+        color: '#555',
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+      }}>
+        Preview
+      </div>
+      <iframe
+        srcDoc={html}
+        title="Email Preview"
+        style={{ width: '100%', height: 600, border: 'none', display: 'block' }}
+        sandbox="allow-same-origin"
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Connects the block builder to the backend. Preview button renders generated HTML in an iframe; Download button exports it as a `.html` file.

## Changes
- `src/api/generate.ts` — fetch wrapper for `POST /api/generate`
- `src/components/preview/PreviewPanel.tsx` — sandboxed iframe HTML preview
- `src/App.tsx` — Preview + Download buttons in header with loading/error state

## Testing
- [x] TypeScript build passes
- [x] 44/44 .NET tests passing
- [ ] Manual: click Preview → iframe renders email; click Download → .html file downloaded

Closes #7
Part of #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)