### PR TITLE
fix(ui): guard hero image preview and fix iframe sandbox permissions

### DIFF
--- a/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
@@ -23,8 +23,13 @@ export function HeroBlockEditor({ block, onChange }: Props) {
         onChange={e => onChange({ ...block, headline: e.target.value })}
         style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
       />
-      {block.imageUrl && (
-        <img src={block.imageUrl} alt="preview" style={{ maxWidth: '100%', maxHeight: 120, objectFit: 'cover', borderRadius: 4 }} />
+      {block.imageUrl.startsWith('http') && (
+        <img
+          src={block.imageUrl}
+          alt="preview"
+          onError={e => { (e.currentTarget as HTMLImageElement).style.display = 'none'; }}
+          style={{ maxWidth: '100%', maxHeight: 120, objectFit: 'cover', borderRadius: 4 }}
+        />
       )}
     </div>
   );

--- a/EmailEditor/ClientApp/src/components/preview/PreviewPanel.tsx
+++ b/EmailEditor/ClientApp/src/components/preview/PreviewPanel.tsx
@@ -29,7 +29,7 @@ export function PreviewPanel({ html }: Props) {
         srcDoc={html}
         title="Email Preview"
         style={{ width: '100%', height: 600, border: 'none', display: 'block' }}
-        sandbox="allow-same-origin"
+        sandbox="allow-scripts"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
Fixes two bugs reported during local testing.

**Bug 1 — Broken hero image preview**
The editor rendered `<img src={url}>` on every keystroke, showing a broken image while the user was still typing. Now only renders when the URL starts with `http`, and hides via `onError` if the image still fails to load.

**Bug 2 — Sandboxed iframe console error**
`sandbox="allow-same-origin"` without `allow-scripts` blocks all script execution and emits a console error for any script in the preview HTML. Changed to `sandbox="allow-scripts"` — scripts run inside the iframe but the iframe cannot access the parent DOM (no same-origin grant).

## Test plan
- [x] TypeScript build passes
- [ ] Add a Hero block, type partial URL → no broken image shown
- [ ] Paste complete image URL → thumbnail appears
- [ ] Click Preview → no script-blocked console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)