### PR TITLE
feat(client): mergeData state + API plumbing (#21)

### DIFF
--- a/EmailEditor/ClientApp/src/App.tsx
+++ b/EmailEditor/ClientApp/src/App.tsx
@@ -107,6 +107,7 @@ const btnBase: React.CSSProperties = {
 
 export default function App() {
   const [blocks, setBlocks] = useState<EmailBlock[]>([]);
+  const [mergeData, setMergeData] = useState<string>('');
   const [activeId, setActiveId] = useState<string | null>(null);
   const [previewHtml, setPreviewHtml] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -176,11 +177,16 @@ export default function App() {
     return { blocks };
   }
 
+  function parsedMergeData(): object | undefined {
+    if (!mergeData.trim()) return undefined;
+    try { return JSON.parse(mergeData); } catch { return undefined; }
+  }
+
   async function handlePreview() {
     setLoading(true);
     setError(null);
     try {
-      const html = await generateHtml(buildDocument());
+      const html = await generateHtml(buildDocument(), parsedMergeData());
       setPreviewHtml(html);
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Unknown error');
@@ -249,7 +255,7 @@ export default function App() {
         onDragCancel={() => setActiveId(null)}
       >
         <div style={{ display: 'flex', gap: 16, padding: 16, maxWidth: 1200, margin: '0 auto' }}>
-          <BlockPalette onAdd={addBlock} />
+          <BlockPalette onAdd={addBlock} mergeData={mergeData} onMergeDataChange={setMergeData} />
           <div style={{ flex: 1 }}>
             <BlockCanvas blocks={blocks} onBlocksChange={setBlocks} containerId="root" />
             <PreviewPanel html={previewHtml} />

--- a/EmailEditor/ClientApp/src/api/generate.ts
+++ b/EmailEditor/ClientApp/src/api/generate.ts
@@ -1,10 +1,11 @@
 import type { EmailDocument } from '../types/blocks';
 
-export async function generateHtml(doc: EmailDocument): Promise<string> {
+export async function generateHtml(doc: EmailDocument, mergeData?: object): Promise<string> {
+  const payload = mergeData ? { ...doc, mergeData } : doc;
   const response = await fetch('/api/generate', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(doc),
+    body: JSON.stringify(payload),
   });
 
   if (!response.ok) {

--- a/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
@@ -12,6 +12,8 @@ const BLOCK_TYPES: { type: BlockType; label: string; icon: string }[] = [
 interface Props {
   onAdd: (type: BlockType) => void;
   compact?: boolean;
+  mergeData?: string;
+  onMergeDataChange?: (value: string) => void;
 }
 
 export function BlockPalette({ onAdd, compact = false }: Props) {


### PR DESCRIPTION
## Description
Adds `mergeData: string` state to App.tsx. Preview passes parsed JSON to the API; download omits it. `api/generate.ts` forwards the optional payload. `BlockPalette` props pre-wired for #22's DataTab.

## Changes
- `App.tsx`: mergeData state, parsedMergeData(), handlePreview wired, handleDownload unchanged
- `api/generate.ts`: optional mergeData param merged into POST body
- `BlockPalette.tsx`: optional mergeData/onMergeDataChange props (consumed in #22)

## Testing
- [x] Validation passes (61 tests, TypeScript clean)

## Checklist
- [x] Architecture conventions respected
- [x] All tests pass locally

Closes #21