### PR TITLE
feat(client): DataTab + two-tab sidebar (#22)

### DIFF
--- a/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/BlockPalette.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import type { BlockType } from '../../types/blocks';
+import { DataTab } from './DataTab';
 
 const BLOCK_TYPES: { type: BlockType; label: string; icon: string }[] = [
   { type: 'hero',      label: 'Hero',       icon: '🖼️' },
@@ -16,7 +18,24 @@ interface Props {
   onMergeDataChange?: (value: string) => void;
 }
 
-export function BlockPalette({ onAdd, compact = false }: Props) {
+const tabStyle = (active: boolean): React.CSSProperties => ({
+  flex: 1,
+  padding: '6px 0',
+  background: 'none',
+  border: 'none',
+  borderBottom: active ? '2px solid #3b82f6' : '2px solid transparent',
+  cursor: 'pointer',
+  fontWeight: active ? 700 : 400,
+  fontSize: 12,
+  color: active ? '#3b82f6' : '#555',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+  transition: 'color 0.15s, border-color 0.15s',
+});
+
+export function BlockPalette({ onAdd, compact = false, mergeData = '', onMergeDataChange }: Props) {
+  const [activeTab, setActiveTab] = useState<'blocks' | 'data'>('blocks');
+
   if (compact) {
     return (
       <div style={{ display: 'flex', flexWrap: 'wrap' as const, gap: 4 }}>
@@ -49,41 +68,58 @@ export function BlockPalette({ onAdd, compact = false }: Props) {
 
   return (
     <aside style={{
-      width: 160,
+      width: 180,
       flexShrink: 0,
       background: '#f8f8f8',
       border: '1px solid #e0e0e0',
       borderRadius: 8,
-      padding: 16,
+      display: 'flex',
+      flexDirection: 'column',
+      overflow: 'hidden',
     }}>
-      <div style={{ fontWeight: 700, fontSize: 13, color: '#555', marginBottom: 12, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
-        Blocks
+      {/* Tab switcher */}
+      <div style={{ display: 'flex', borderBottom: '1px solid #e0e0e0', padding: '0 8px' }}>
+        <button style={tabStyle(activeTab === 'blocks')} onClick={() => setActiveTab('blocks')}>
+          Blocks
+        </button>
+        <button style={tabStyle(activeTab === 'data')} onClick={() => setActiveTab('data')}>
+          Data
+        </button>
       </div>
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-        {BLOCK_TYPES.map(({ type, label, icon }) => (
-          <button
-            key={type}
-            onClick={() => onAdd(type)}
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              gap: 8,
-              padding: '8px 10px',
-              background: '#fff',
-              border: '1px solid #ddd',
-              borderRadius: 6,
-              cursor: 'pointer',
-              fontSize: 13,
-              textAlign: 'left',
-              transition: 'background 0.15s',
-            }}
-            onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
-            onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
-          >
-            <span>{icon}</span>
-            <span>{label}</span>
-          </button>
-        ))}
+
+      <div style={{ padding: '0 12px', flex: 1, overflowY: 'auto' }}>
+        {activeTab === 'blocks' && (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 6, padding: '12px 0' }}>
+            {BLOCK_TYPES.map(({ type, label, icon }) => (
+              <button
+                key={type}
+                onClick={() => onAdd(type)}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  padding: '8px 10px',
+                  background: '#fff',
+                  border: '1px solid #ddd',
+                  borderRadius: 6,
+                  cursor: 'pointer',
+                  fontSize: 13,
+                  textAlign: 'left',
+                  transition: 'background 0.15s',
+                }}
+                onMouseEnter={e => (e.currentTarget.style.background = '#f0f0f0')}
+                onMouseLeave={e => (e.currentTarget.style.background = '#fff')}
+              >
+                <span>{icon}</span>
+                <span>{label}</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {activeTab === 'data' && (
+          <DataTab value={mergeData} onChange={onMergeDataChange ?? (() => {})} />
+        )}
       </div>
     </aside>
   );

--- a/EmailEditor/ClientApp/src/components/editor/DataTab.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/DataTab.tsx
@@ -1,0 +1,89 @@
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+/** Flattens a parsed JSON object into dot-path leaf keys. */
+export function flattenKeys(obj: unknown, prefix = ''): string[] {
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) return [];
+  const result: string[] = [];
+  for (const [key, val] of Object.entries(obj as Record<string, unknown>)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (val !== null && typeof val === 'object' && !Array.isArray(val)) {
+      result.push(...flattenKeys(val, path));
+    } else {
+      result.push(path);
+    }
+  }
+  return result;
+}
+
+export function DataTab({ value, onChange }: Props) {
+  let parsed: unknown = null;
+  let parseError = '';
+  if (value.trim()) {
+    try {
+      parsed = JSON.parse(value);
+    } catch {
+      parseError = 'Invalid JSON';
+    }
+  }
+
+  const fields = parsed ? flattenKeys(parsed) : [];
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 12, padding: '12px 0' }}>
+      <textarea
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        placeholder={'{\n  "person": {\n    "firstName": "Alice"\n  }\n}'}
+        spellCheck={false}
+        style={{
+          width: '100%',
+          minHeight: 160,
+          fontFamily: 'monospace',
+          fontSize: 12,
+          padding: 8,
+          border: `1px solid ${parseError ? '#f87171' : '#ccc'}`,
+          borderRadius: 4,
+          resize: 'vertical',
+          boxSizing: 'border-box',
+          outline: 'none',
+        }}
+      />
+      {parseError && (
+        <div style={{ fontSize: 12, color: '#ef4444' }}>{parseError}</div>
+      )}
+      {!parseError && fields.length === 0 && (
+        <div style={{ fontSize: 12, color: '#aaa', textAlign: 'center', padding: '8px 0' }}>
+          No merge fields yet
+        </div>
+      )}
+      {fields.length > 0 && (
+        <div>
+          <div style={{ fontSize: 11, fontWeight: 600, color: '#555', marginBottom: 6, textTransform: 'uppercase', letterSpacing: '0.05em' }}>
+            Available Fields
+          </div>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+            {fields.map(f => (
+              <div
+                key={f}
+                style={{
+                  fontSize: 12,
+                  fontFamily: 'monospace',
+                  background: '#f0f4ff',
+                  border: '1px solid #c7d2fe',
+                  borderRadius: 4,
+                  padding: '3px 8px',
+                  color: '#3730a3',
+                }}
+              >
+                {`{{${f}}}`}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Replaces the single-mode BlockPalette sidebar with a two-tab layout. "Blocks" tab shows the existing palette; "Data" tab shows the new DataTab with a JSON textarea, inline parse error, and a list of available `{{field.path}}` merge field paths.

## Changes
- New: `DataTab.tsx` — textarea, flattenKeys(), field list, empty/error states
- Modified: `BlockPalette.tsx` — tab switcher, routes to DataTab when "Data" active

## Testing
- [x] Validation passes (61 tests, TypeScript clean)

Closes #22