### PR TITLE
feat(client): MergeFieldChips + editor integration (#23)

### DIFF
--- a/EmailEditor/ClientApp/src/App.tsx
+++ b/EmailEditor/ClientApp/src/App.tsx
@@ -14,6 +14,8 @@ import { sortableKeyboardCoordinates, arrayMove } from '@dnd-kit/sortable';
 import { BlockPalette } from './components/editor/BlockPalette';
 import { BlockCanvas } from './components/editor/BlockCanvas';
 import { PreviewPanel } from './components/preview/PreviewPanel';
+import { MergeFieldsContext } from './components/editor/MergeFieldChips';
+import { flattenKeys } from './components/editor/DataTab';
 import type { EmailBlock, BlockType, TwoColumnBlock } from './types/blocks';
 import { createBlock } from './types/blocks';
 import { generateHtml } from './api/generate';
@@ -247,6 +249,9 @@ export default function App() {
         </div>
       )}
 
+      <MergeFieldsContext.Provider value={(() => {
+        try { return mergeData.trim() ? flattenKeys(JSON.parse(mergeData)) : []; } catch { return []; }
+      })()}>
       <DndContext
         sensors={sensors}
         collisionDetection={closestCenter}
@@ -288,6 +293,7 @@ export default function App() {
           })() : null}
         </DragOverlay>
       </DndContext>
+      </MergeFieldsContext.Provider>
     </div>
   );
 }

--- a/EmailEditor/ClientApp/src/components/blocks/ButtonBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/ButtonBlockEditor.tsx
@@ -1,21 +1,48 @@
+import { useRef } from 'react';
 import type { ButtonBlock } from '../../types/blocks';
+import { MergeFieldChips, useMergeFields } from '../editor/MergeFieldChips';
 
 interface Props {
   block: ButtonBlock;
   onChange: (updated: ButtonBlock) => void;
 }
 
+function insertAt(value: string, token: string, start: number): string {
+  return value.slice(0, start) + token + value.slice(start);
+}
+
 export function ButtonBlockEditor({ block, onChange }: Props) {
+  const labelRef = useRef<HTMLInputElement>(null);
+  const labelCursor = useRef<number>(0);
+  const fieldPaths = useMergeFields();
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <label style={{ fontWeight: 600 }}>Button / CTA</label>
-      <input
-        type="text"
-        placeholder="Button label"
-        value={block.label}
-        onChange={e => onChange({ ...block, label: e.target.value })}
-        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
-      />
+      <div>
+        <input
+          ref={labelRef}
+          type="text"
+          placeholder="Button label"
+          value={block.label}
+          onChange={e => onChange({ ...block, label: e.target.value })}
+          onSelect={e => { labelCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          onKeyUp={e => { labelCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4, width: '100%', boxSizing: 'border-box' }}
+        />
+        <MergeFieldChips
+          fieldPaths={fieldPaths}
+          onInsert={token => {
+            const pos = labelCursor.current;
+            onChange({ ...block, label: insertAt(block.label, token, pos) });
+            labelCursor.current = pos + token.length;
+            requestAnimationFrame(() => {
+              labelRef.current?.focus();
+              labelRef.current?.setSelectionRange(pos + token.length, pos + token.length);
+            });
+          }}
+        />
+      </div>
       <input
         type="text"
         placeholder="URL (https://...)"

--- a/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/HeroBlockEditor.tsx
@@ -1,11 +1,22 @@
+import { useRef } from 'react';
 import type { HeroBlock } from '../../types/blocks';
+import { MergeFieldChips, useMergeFields } from '../editor/MergeFieldChips';
 
 interface Props {
   block: HeroBlock;
   onChange: (updated: HeroBlock) => void;
 }
 
+/** Splices `token` into `value` at `start`, returns new string. */
+function insertAt(value: string, token: string, start: number): string {
+  return value.slice(0, start) + token + value.slice(start);
+}
+
 export function HeroBlockEditor({ block, onChange }: Props) {
+  const headlineRef = useRef<HTMLInputElement>(null);
+  const headlineCursor = useRef<number>(0);
+  const fieldPaths = useMergeFields();
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <label style={{ fontWeight: 600 }}>Hero Block</label>
@@ -16,13 +27,32 @@ export function HeroBlockEditor({ block, onChange }: Props) {
         onChange={e => onChange({ ...block, imageUrl: e.target.value })}
         style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
       />
-      <input
-        type="text"
-        placeholder="Headline"
-        value={block.headline}
-        onChange={e => onChange({ ...block, headline: e.target.value })}
-        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
-      />
+      <div>
+        <input
+          ref={headlineRef}
+          type="text"
+          placeholder="Headline"
+          value={block.headline}
+          onChange={e => onChange({ ...block, headline: e.target.value })}
+          onSelect={e => { headlineCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          onKeyUp={e => { headlineCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4, width: '100%', boxSizing: 'border-box' }}
+        />
+        <MergeFieldChips
+          fieldPaths={fieldPaths}
+          onInsert={token => {
+            const pos = headlineCursor.current;
+            const next = insertAt(block.headline, token, pos);
+            onChange({ ...block, headline: next });
+            headlineCursor.current = pos + token.length;
+            // restore focus + cursor
+            requestAnimationFrame(() => {
+              headlineRef.current?.focus();
+              headlineRef.current?.setSelectionRange(pos + token.length, pos + token.length);
+            });
+          }}
+        />
+      </div>
       {block.imageUrl.startsWith('http') && (
         <img
           src={block.imageUrl}

--- a/EmailEditor/ClientApp/src/components/blocks/ImageBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/ImageBlockEditor.tsx
@@ -1,11 +1,21 @@
+import { useRef } from 'react';
 import type { ImageBlock } from '../../types/blocks';
+import { MergeFieldChips, useMergeFields } from '../editor/MergeFieldChips';
 
 interface Props {
   block: ImageBlock;
   onChange: (updated: ImageBlock) => void;
 }
 
+function insertAt(value: string, token: string, start: number): string {
+  return value.slice(0, start) + token + value.slice(start);
+}
+
 export function ImageBlockEditor({ block, onChange }: Props) {
+  const altRef = useRef<HTMLInputElement>(null);
+  const altCursor = useRef<number>(0);
+  const fieldPaths = useMergeFields();
+
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
       <label style={{ fontWeight: 600 }}>Image Block</label>
@@ -16,13 +26,30 @@ export function ImageBlockEditor({ block, onChange }: Props) {
         onChange={e => onChange({ ...block, imageUrl: e.target.value })}
         style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
       />
-      <input
-        type="text"
-        placeholder="Alt text"
-        value={block.altText}
-        onChange={e => onChange({ ...block, altText: e.target.value })}
-        style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4 }}
-      />
+      <div>
+        <input
+          ref={altRef}
+          type="text"
+          placeholder="Alt text"
+          value={block.altText}
+          onChange={e => onChange({ ...block, altText: e.target.value })}
+          onSelect={e => { altCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          onKeyUp={e => { altCursor.current = (e.target as HTMLInputElement).selectionStart ?? 0; }}
+          style={{ padding: '6px 8px', border: '1px solid #ccc', borderRadius: 4, width: '100%', boxSizing: 'border-box' }}
+        />
+        <MergeFieldChips
+          fieldPaths={fieldPaths}
+          onInsert={token => {
+            const pos = altCursor.current;
+            onChange({ ...block, altText: insertAt(block.altText, token, pos) });
+            altCursor.current = pos + token.length;
+            requestAnimationFrame(() => {
+              altRef.current?.focus();
+              altRef.current?.setSelectionRange(pos + token.length, pos + token.length);
+            });
+          }}
+        />
+      </div>
       {block.imageUrl && (
         <img src={block.imageUrl} alt={block.altText} style={{ maxWidth: '100%', maxHeight: 120, objectFit: 'cover', borderRadius: 4 }} />
       )}

--- a/EmailEditor/ClientApp/src/components/blocks/TextBlockEditor.tsx
+++ b/EmailEditor/ClientApp/src/components/blocks/TextBlockEditor.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef } from 'react';
 import Quill from 'quill';
 import 'quill/dist/quill.snow.css';
 import type { TextBlock } from '../../types/blocks';
+import { MergeFieldChips, useMergeFields } from '../editor/MergeFieldChips';
 
 interface Props {
   block: TextBlock;
@@ -13,6 +14,7 @@ export function TextBlockEditor({ block, onChange }: Props) {
   const quillRef = useRef<Quill | null>(null);
   const blockIdRef = useRef(block.id);
   const onChangeRef = useRef(onChange);
+  const savedSelectionRef = useRef<{ index: number; length: number } | null>(null);
 
   // Keep onChangeRef current so the Quill handler always calls the latest onChange
   useEffect(() => { onChangeRef.current = onChange; });
@@ -29,15 +31,30 @@ export function TextBlockEditor({ block, onChange }: Props) {
     quillRef.current.on('text-change', () => {
       onChangeRef.current({ ...block, id: blockIdRef.current, htmlContent: quillRef.current!.root.innerHTML });
     });
+    // Track last known selection so chip clicks can insert at the right position
+    quillRef.current.on('selection-change', (range) => {
+      if (range) savedSelectionRef.current = range;
+    });
   }, []);
 
-  // Update blockIdRef when block.id changes (shouldn't normally happen)
   useEffect(() => { blockIdRef.current = block.id; }, [block.id]);
+
+  const fieldPaths = useMergeFields();
+
+  function handleInsert(token: string) {
+    const q = quillRef.current;
+    if (!q) return;
+    const idx = savedSelectionRef.current?.index ?? q.getLength() - 1;
+    q.focus();
+    q.insertText(idx, token, 'user');
+    q.setSelection(idx + token.length, 0);
+  }
 
   return (
     <div>
       <label style={{ fontWeight: 600, display: 'block', marginBottom: 6 }}>Text Block</label>
       <div ref={editorRef} style={{ minHeight: 100 }} />
+      <MergeFieldChips fieldPaths={fieldPaths} onInsert={handleInsert} />
     </div>
   );
 }

--- a/EmailEditor/ClientApp/src/components/editor/MergeFieldChips.tsx
+++ b/EmailEditor/ClientApp/src/components/editor/MergeFieldChips.tsx
@@ -1,0 +1,57 @@
+import { createContext, useContext } from 'react';
+
+// ── Context ───────────────────────────────────────────────────────────────────
+
+export const MergeFieldsContext = createContext<string[]>([]);
+export function useMergeFields() { return useContext(MergeFieldsContext); }
+
+// ── MergeFieldChips ───────────────────────────────────────────────────────────
+
+interface Props {
+  /** Leaf-path keys from the parsed JSON e.g. ["person.firstName", "order.total"] */
+  fieldPaths: string[];
+  /** Called with the full token e.g. "{{person.firstName}}" */
+  onInsert: (token: string) => void;
+}
+
+const chipStyle: React.CSSProperties = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  padding: '2px 8px',
+  fontSize: 11,
+  fontFamily: 'monospace',
+  background: '#eff6ff',
+  border: '1px solid #bfdbfe',
+  borderRadius: 4,
+  color: '#1d4ed8',
+  cursor: 'pointer',
+  whiteSpace: 'nowrap',
+  userSelect: 'none',
+  lineHeight: 1.6,
+};
+
+export function MergeFieldChips({ fieldPaths, onInsert }: Props) {
+  if (fieldPaths.length === 0) {
+    return (
+      <div style={{ fontSize: 11, color: '#aaa', marginTop: 4 }}>
+        No merge fields — add data in the Data tab
+      </div>
+    );
+  }
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, marginTop: 4 }}>
+      {fieldPaths.map(path => (
+        <button
+          key={path}
+          // preventDefault keeps focus on the active editor (Quill or input)
+          onMouseDown={e => { e.preventDefault(); onInsert(`{{${path}}}`); }}
+          style={chipStyle}
+          title={`Insert {{${path}}}`}
+        >
+          {`{{${path}}}`}
+        </button>
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
## Description
Shared MergeFieldChips component + wiring into all text-capable block editors. MergeFieldsContext provides field paths globally so no prop-drilling through BlockCanvas.

## Changes
- New: `MergeFieldChips.tsx` — chip row + `MergeFieldsContext` + `useMergeFields()`
- `TextBlockEditor`: saves Quill selection, inserts at cursor position
- `HeroBlockEditor`, `ButtonBlockEditor`, `ImageBlockEditor`: track input cursor, splice on chip click
- `App.tsx`: provides `MergeFieldsContext` with flattenKeys(parsedMergeData)

## Testing
- [x] Validation passes (61 tests, TypeScript clean)

Closes #23