### PR TITLE
infra: install and configure @xero/xui and sass (#40)

### DIFF
--- a/EmailEditor/ClientApp/package-lock.json
+++ b/EmailEditor/ClientApp/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@xero/xui": "file:../../../xui",
         "quill": "^2.0.3",
         "react": "^19.2.4",
         "react-dom": "^19.2.4"
@@ -25,9 +26,187 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.4.0",
+        "sass": "^1.98.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^8.0.1"
+      }
+    },
+    "../../../xui": {
+      "name": "@xero/xui",
+      "version": "24.0.0-xdl.12",
+      "dependencies": {
+        "@tanstack/react-table": "8.21.3",
+        "@xero/blind-date": "2.5.10",
+        "@xero/xui-icon": "6.9.0-xdl.2",
+        "@xero/xui-tokens": "14.6.0",
+        "autosize": "6.0.1",
+        "clsx": "^1.2.1",
+        "core-js": "^3.37.1",
+        "date-fns": "3.6.0",
+        "dayjs": "^1.11.13",
+        "lodash.debounce": "^4.0.8",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.throttle": "^4.1.1",
+        "memoize-one": "6.0.0",
+        "nanoid": "^3.3.11",
+        "path": "0.12.7",
+        "prop-types": "^15.7.2",
+        "react-beautiful-dnd": "13.1.1",
+        "react-day-picker": "9.4.0",
+        "react-portal": "^4.3.0",
+        "resize-observer-polyfill": "1.5.1",
+        "scrollbar-width": "3.1.1",
+        "verge": "1.10.2",
+        "weekstart": "2.0.0"
+      },
+      "devDependencies": {
+        "@babel/cli": "^7.24.8",
+        "@babel/core": "^7.24.9",
+        "@babel/parser": "^7.24.8",
+        "@babel/plugin-proposal-object-rest-spread": "^7.19.4",
+        "@babel/plugin-transform-exponentiation-operator": "^7.24.7",
+        "@babel/plugin-transform-react-jsx-source": "^7.24.7",
+        "@babel/plugin-transform-runtime": "^7.24.7",
+        "@babel/polyfill": "^7.10.1",
+        "@babel/preset-env": "^7.24.8",
+        "@babel/preset-react": "^7.24.7",
+        "@babel/preset-typescript": "^7.24.7",
+        "@babel/register": "^7.24.6",
+        "@babel/runtime": "^7.24.8",
+        "@commitlint/cli": "^19.8.0",
+        "@commitlint/config-conventional": "^19.8.0",
+        "@digitalroute/cz-conventional-changelog-for-jira": "8.0.1",
+        "@storybook/addon-a11y": "10.2.8",
+        "@storybook/addon-docs": "10.2.17",
+        "@storybook/addon-mcp": "0.2.2",
+        "@storybook/addon-webpack5-compiler-swc": "4.0.2",
+        "@storybook/react": "10.2.1",
+        "@storybook/react-webpack5": "10.2.8",
+        "@testing-library/jest-dom": "6.6.3",
+        "@testing-library/react": "14.3.1",
+        "@testing-library/user-event": "14.6.1",
+        "@types/fs-extra": "11.0.4",
+        "@types/jest": "^29.5.13",
+        "@types/jest-axe": "^3.5.9",
+        "@types/prop-types": "^15.7.12",
+        "@types/react": "18.3.3",
+        "@types/react-beautiful-dnd": "^13.1.8",
+        "@types/react-dom": "^18.3.0",
+        "@types/react-portal": "^4.0.7",
+        "@typescript-eslint/eslint-plugin": "^7.16.1",
+        "@typescript-eslint/parser": "^7.16.1",
+        "@xero/babel-preset-xero": "2.2.1",
+        "@xero/browserslist-autoprefixer": "^7.0.0",
+        "@xero/xuishift": "4.3.2",
+        "acorn": "^8.14.0",
+        "autoprefixer": "^10.4.21",
+        "babel-jest": "^29.7.0",
+        "babel-loader": "^9.1.3",
+        "babel-plugin-transform-react-remove-prop-types": "0.4.24",
+        "babel-plugin-transform-require-ignore": "0.1.1",
+        "backstopjs": "6.3.11",
+        "browserslist": "^4.24.4",
+        "chalk": "^4.1.2",
+        "check-engines": "^1.6.0",
+        "chrome-killer": "^2.2.1",
+        "clean-css": "~5.3.1",
+        "commitizen": "^4.3.1",
+        "cross-env": "^7.0.3",
+        "cross-spawn": "^7.0.6",
+        "css-loader": "6.10.0",
+        "cssnano": "7.1.2",
+        "dockerode": "^4.0.5",
+        "eslint": "8.57.0",
+        "eslint-config-airbnb": "19.0.4",
+        "eslint-config-airbnb-typescript": "17.1.0",
+        "eslint-config-prettier": "9.1.0",
+        "eslint-plugin-filenames": "1.3.2",
+        "eslint-plugin-import": "2.29.1",
+        "eslint-plugin-jest": "27.9.0",
+        "eslint-plugin-jsx-a11y": "6.8.0",
+        "eslint-plugin-prefer-arrow": "1.2.3",
+        "eslint-plugin-prettier": "5.1.3",
+        "eslint-plugin-react": "7.31.10",
+        "eslint-plugin-react-hooks": "4.6.0",
+        "eslint-plugin-simple-import-sort": "12.0.0",
+        "eslint-plugin-storybook": "10.2.1",
+        "eslint-plugin-testing-library": "6.2.0",
+        "eslint-plugin-typescript-sort-keys": "3.2.0",
+        "eslint-restricted-globals": "0.2.0",
+        "file-loader": "^6.2.0",
+        "fork-ts-checker-webpack-plugin": "^9.1.0",
+        "fs-extra": "^11.3.0",
+        "gaze": "^1.1.3",
+        "http-server": "14.1.1",
+        "husky": "^9.1.7",
+        "inquirer": "^8.1.4",
+        "jest": "^29.7.0",
+        "jest-axe": "^8.0.0",
+        "jest-environment-jsdom": "^29.7.0",
+        "jest-jasmine2": "^29.7.0",
+        "jest-runner-vscode": "3.0.1",
+        "lint-staged": "^15.2.2",
+        "lodash": "4.17.21",
+        "log-update": "^4.0.0",
+        "make-runnable": "^1.4.1",
+        "marked": "^12.0.0",
+        "maxmin": "^4.1.0",
+        "md5-file": "^5.0.0",
+        "mini-css-extract-plugin": "2.9.0",
+        "mkdirp": "^3.0.1",
+        "ncp": "^2.0.0",
+        "nodemon": "^3.1.9",
+        "nopt": "^7.2.1",
+        "npm-run-all": "^4.1.5",
+        "open": "^8.2.1",
+        "ora": "^8.2.0",
+        "pm2": "^5.3.1",
+        "postcss": "8.4.35",
+        "postcss-discard-comments": "6.0.1",
+        "postcss-easy-import": "4.0.0",
+        "postcss-loader": "8.1.1",
+        "postcss-scss": "4.0.9",
+        "prettier": "^3.5.3",
+        "raw-loader": "^4.0.2",
+        "react": "18.2.0",
+        "react-dom": "18.2.0",
+        "react-is": "^18.3.1",
+        "react-test-renderer": "^18.2.0",
+        "recast": "^0.23.5",
+        "regenerator-runtime": "^0.14.0",
+        "rimraf": "^3.0.2",
+        "sass": "^1.97.3",
+        "sass-embedded": "^1.97.3",
+        "sass-loader": "14.1.1",
+        "semver": "7.7.1",
+        "serve-static": "^1.14.1",
+        "simple-mock": "^0.8.0",
+        "snapshot-diff": "^0.10.0",
+        "storybook": "^10.2.1",
+        "style-loader": "^3.3.1",
+        "stylelint": "^15.11.0",
+        "stylelint-a11y": "^1.2.3",
+        "stylelint-config-prettier": "9.0.5",
+        "stylelint-config-standard-scss": "11.0.0",
+        "stylelint-order": "^6.0.3",
+        "stylelint-stylistic": "0.4.5",
+        "tiny-lr": "^2.0.0",
+        "tinycolor2": "^1.6.0",
+        "typescript": "^5.8.3",
+        "uppercamelcase": "^3.0.0",
+        "webpack": "5.93.0",
+        "webpack-cli": "5.1.4",
+        "workbox-build": "^7.3.0",
+        "yargs": "^17.7.2"
+      },
+      "engines": {
+        "node": ">=20.19.0",
+        "npm": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -641,6 +820,334 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@parcel/watcher": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+      "integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.3",
+        "is-glob": "^4.0.3",
+        "node-addon-api": "^7.0.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher-android-arm64": "2.5.6",
+        "@parcel/watcher-darwin-arm64": "2.5.6",
+        "@parcel/watcher-darwin-x64": "2.5.6",
+        "@parcel/watcher-freebsd-x64": "2.5.6",
+        "@parcel/watcher-linux-arm-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm-musl": "2.5.6",
+        "@parcel/watcher-linux-arm64-glibc": "2.5.6",
+        "@parcel/watcher-linux-arm64-musl": "2.5.6",
+        "@parcel/watcher-linux-x64-glibc": "2.5.6",
+        "@parcel/watcher-linux-x64-musl": "2.5.6",
+        "@parcel/watcher-win32-arm64": "2.5.6",
+        "@parcel/watcher-win32-ia32": "2.5.6",
+        "@parcel/watcher-win32-x64": "2.5.6"
+      }
+    },
+    "node_modules/@parcel/watcher-android-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+      "integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+      "integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-darwin-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+      "integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-freebsd-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+      "integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+      "integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+      "integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+      "integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-arm64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+      "integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-glibc": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+      "integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-linux-x64-musl": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+      "integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-arm64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+      "integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-ia32": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+      "integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/@parcel/watcher-win32-x64": {
+      "version": "2.5.6",
+      "resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+      "integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
@@ -1299,6 +1806,10 @@
         }
       }
     },
+    "node_modules/@xero/xui": {
+      "resolved": "../../../xui",
+      "link": true
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -1473,6 +1984,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chokidar": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
+      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/color-convert": {
@@ -1969,6 +2496,13 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
+      "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -2489,6 +3023,14 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/node-addon-api": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
+      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.36",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
@@ -2704,6 +3246,20 @@
         "react": "^19.2.4"
       }
     },
+    "node_modules/readdirp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
+      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.18.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -2754,6 +3310,27 @@
       "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/sass": {
+      "version": "1.98.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.98.0.tgz",
+      "integrity": "sha512-+4N/u9dZ4PrgzGgPlKnaaRQx64RO0JBKs9sDhQ2pLgN6JQZ25uPQZKQYaBJU48Kd5BxgXoJ4e09Dq7nMcOUW3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^4.0.0",
+        "immutable": "^5.1.5",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "@parcel/watcher": "^2.4.1"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",

--- a/EmailEditor/ClientApp/package.json
+++ b/EmailEditor/ClientApp/package.json
@@ -13,6 +13,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@xero/xui": "file:../../../xui",
     "quill": "^2.0.3",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
@@ -27,6 +28,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.4.0",
+    "sass": "^1.98.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^8.0.1"

--- a/EmailEditor/ClientApp/src/main.tsx
+++ b/EmailEditor/ClientApp/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import '@xero/xui/dist/css/xui.css'
 import './index.css'
 import App from './App.tsx'
 

--- a/EmailEditor/ClientApp/vite.config.ts
+++ b/EmailEditor/ClientApp/vite.config.ts
@@ -4,6 +4,12 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  build: {
+    // XUI's CSS contains selectors that Vite 8's lightningcss minifier
+    // can't parse (pseudo-element followed by pseudo-class). Use esbuild
+    // minifier for CSS instead.
+    cssMinify: false,
+  },
   server: {
     proxy: {
       '/api': {


### PR DESCRIPTION
## Description
Foundation for XUI component adoption. Builds @xero/xui from source, installs it as a local path dependency, and wires the XUI stylesheet into the app.

## Changes
- `@xero/xui` installed via local path (`file:../../../xui`) with `--legacy-peer-deps` (React 19 vs XUI's ^18 peer dep)
- `sass` installed as dev dependency
- `import '@xero/xui/dist/css/xui.css'` added to `main.tsx` (prebuilt CSS used instead of SCSS to avoid Dart Sass @import deprecation warnings)
- `cssMinify: false` in `vite.config.ts` — Vite 8's lightningcss minifier can't parse a pseudo-element + pseudo-class selector in XUI's datepicker CSS

## Testing
- [x] `npm run build` passes (747 modules)
- [x] 61/61 backend tests pass

## Checklist
- [x] No breaking changes — CSS only added, no components used yet
- [x] Unblocks #41 and #42

Closes #40